### PR TITLE
Exception when updating without packages

### DIFF
--- a/lib/core/manager.js
+++ b/lib/core/manager.js
@@ -103,6 +103,8 @@ Manager.prototype.resolveFromJson = function () {
 
   this.once('loadJSON', function () {
 
+    if (!this.json.dependencies) return this.emit('error', new Error('Could not find any dependencies'));
+
     async.forEach(Object.keys(this.json.dependencies), function (name, next) {
       var endpoint = this.json.dependencies[name];
       var pkg      = new Package(name, endpoint, this);


### PR DESCRIPTION
If you start a new project with the following params, for example:

`{ "name": "myapp", "version": "1.0.0" }`

You get a `TypeError`:

`/usr/local/lib/node_modules/bower/lib/core/manager.js:106
    async.forEach(Object.keys(this.json.dependencies), function (name, next) {
                         ^
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at Manager.resolveFromJson (/usr/local/lib/node_modules/bower/lib/core/manager.js:106:26)
    at g (events.js:185:14)
    at EventEmitter.emit (events.js:85:17)
    at Manager.loadJSON (/usr/local/lib/node_modules/bower/lib/core/manager.js:93:12)
    at fs.readFile (fs.js:176:14)
    at fs.close (/usr/local/lib/node_modules/bower/node_modules/glob/node_modules/graceful-fs/graceful-fs.js:92:5)
    at fs.close (/usr/local/lib/node_modules/bower/node_modules/read-package-json/node_modules/graceful-fs/graceful-fs.js:92:5)
    at fs.close (/usr/local/lib/node_modules/bower/node_modules/rimraf/node_modules/graceful-fs/graceful-fs.js:92:5)
    at fs.close (/usr/local/lib/node_modules/bower/node_modules/fstream/node_modules/graceful-fs/graceful-fs.js:92:5)`

Now, it raises an error saying:

`bower error Could not find any dependencies`
