### PR TITLE
Replace Underscore with Lo-Dash

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -11,7 +11,7 @@ var hogan  = require('hogan.js');
 var nopt   = require('nopt');
 var path   = require('path');
 var fs     = require('fs');
-var _      = require('underscore');
+var _      = require('lodash');
 
 var template  = require('../util/template');
 var config    = require('../core/config');

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -12,7 +12,7 @@ var archy   = require('archy');
 var async   = require('async');
 var nopt    = require('nopt');
 var path    = require('path');
-var _       = require('underscore');
+var _       = require('lodash');
 
 var template = require('../util/template');
 var Manager  = require('../core/manager');

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -9,7 +9,7 @@
 var Emitter  = require('events').EventEmitter;
 var async    = require('async');
 var nopt     = require('nopt');
-var _        = require('underscore');
+var _        = require('lodash');
 
 var template = require('../util/template');
 var Manager  = require('../core/manager');

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -9,7 +9,7 @@
 var Emitter = require('events').EventEmitter;
 var async   = require('async');
 var nopt    = require('nopt');
-var _       = require('underscore');
+var _       = require('lodash');
 
 var Manager = require('../core/manager');
 var install = require('./install');

--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -13,7 +13,7 @@
 // ==========================================
 
 var spawn    = require('child_process').spawn;
-var _        = require('underscore');
+var _        = require('lodash');
 var fstream  = require('fstream');
 var mkdirp   = require('mkdirp');
 var events   = require('events');

--- a/lib/core/source.js
+++ b/lib/core/source.js
@@ -7,7 +7,7 @@
 // ==========================================
 
 var request  = require('request');
-var _        = require('underscore');
+var _        = require('lodash');
 
 var endpoint = 'https://bower.herokuapp.com/packages';
 

--- a/lib/util/hogan-colors.js
+++ b/lib/util/hogan-colors.js
@@ -8,7 +8,7 @@
 
 var colors = require('colors');
 var hogan  = require('hogan.js');
-var _      = require('underscore');
+var _      = require('lodash');
 
 module.exports = hogan.Template.prototype.renderWithColors = function (context, partials, indent) {
   context = _.extend({

--- a/lib/util/prune.js
+++ b/lib/util/prune.js
@@ -7,7 +7,7 @@
 // ==========================================
 
 var semver  = require('semver');
-var _       = require('underscore');
+var _       = require('lodash');
 
 var versionRequirements = function (dependencyMap) {
   var result = []

--- a/lib/util/save.js
+++ b/lib/util/save.js
@@ -8,7 +8,7 @@
 
 var path   = require('path');
 var fs     = require('fs');
-var _      = require('underscore');
+var _      = require('lodash');
 
 var config = require('../core/config');
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "request"           : "latest",
     "fstream"           : "latest",
     "hogan.js"          : "latest",
-    "underscore"        : "latest",
+    "lodash"            : "latest",
     "read-package-json" : "latest"
   },
   "scripts": {

--- a/test/package.js
+++ b/test/package.js
@@ -1,7 +1,7 @@
 var assert  = require('assert');
 var path    = require('path');
 var fs      = require('fs');
-var _       = require('underscore');
+var _       = require('lodash');
 var Package = require('../lib/core/package');
 
 describe('package', function () {


### PR DESCRIPTION
All Bower unit tests pass via `make test`.

[Lo-Dash](http://lodash.com) aligns with the core values of Bower and its devs
- Supports package managers like Bower by having its own `component.json`, as well as npm and jam
- Is all about customization and convenience with more custom build options than any other JS utility belt
- Lots of [docs](http://lodash.com/docs)
- Promotes unit testing, holla @fat, with over 600 [unit tests](http://lodash.com/tests), over 2,400 build tests, incorporated Underscore/Backbone unit tests, and its unit tests run in Node / Ringo / Rhino / Narwhal and browsers as well
- Optimizations for V8 and [perf improvements](http://lodash.com/benchmarks)
- Consistency in API behavior, method signatures, and supported arguments

Other considerations:
- Updated more frequently (version bumped ~15 times in the last ~5 months compared to Underscore's ~2 times)
- More bug fixes (less outstanding bugs too)
- More utility methods like `_.partial`, `_.where`, `_.forIn`, and `_.random`
