### PR TITLE
Adding support for specifying bower configuration in package.json

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -156,19 +156,26 @@ Package.prototype.uninstall = function () {
 };
 
 // Private
-Package.prototype.loadJSON = function (name) {
+Package.prototype.loadJSON = function (name, prop) {
   var pathname = name || ( this.assetType ? 'index' + this.assetType : config.json );
 
   readJSON(path.join(this.path, pathname), function (err, json) {
 
     if (err) {
-      if (!name) return this.loadJSON('package.json');
+      if (!name) return this.loadJSON('package.json', 'bower');
+      
       return this.assetUrl ? this.emit('loadJSON') : this.path && this.on('describeTag', function (tag) {
         this.version = this.tag = semver.clean(tag);
         this.emit('loadJSON')
       }.bind(this)).describeTag();
     }
-    this.json    = json;
+
+    if (prop) {
+      this.json = json[prop] || json;
+    } else {
+      this.json = json;  
+    }
+
     this.name    = this.json.name;
     this.version = this.json.version;
     this.emit('loadJSON');

--- a/test/assets/package-only-package-json/package.json
+++ b/test/assets/package-only-package-json/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "other",
+  "description": "Another thing",
+  "version": "0.1.5",
+  "bower" : {
+    "name": "myproject",
+    "version": "1.5.23",
+    "dependencies": {
+      "package-bootstrap": "git://github.com/fat/package-bootstrap.git#~2.0.0",
+      "jquery": "git://github.com/maccman/package-jquery.git#v1.7.2"
+    }
+  }
+}

--- a/test/package.js
+++ b/test/package.js
@@ -91,6 +91,19 @@ describe('package', function () {
     pkg.loadJSON();
   });
 
+  it('Should load correct json from package.json', function (next) {
+    var pkg = new Package('jquery', __dirname + '/assets/package-only-package-json');
+
+    pkg.on('loadJSON', function () {
+      assert(pkg.json);
+      assert.equal(pkg.json.name, 'myproject');
+      assert.equal(pkg.json.version, '1.5.23');
+      next();
+    });
+
+    pkg.loadJSON();
+  });
+
   it('Should resolve JSON dependencies', function (next) {
     var pkg = new Package('project', __dirname + '/assets/project');
 


### PR DESCRIPTION
Adding another json configuration file might seem like too many configuration files for some (especially if custom projects already have their own and that cannot be changed.)

This patch supports adding the bower configuration in package.json under the `bower` property like so:

``` json
{
  "name": "other",
  "description": "Another thing",
  "version": "0.1.5",
  "bower" : {
    "name": "myproject",
    "version": "1.5.23",
    "dependencies": {
      "package-bootstrap": "git://github.com/fat/package-bootstrap.git#~2.0.0",
      "jquery": "git://github.com/maccman/package-jquery.git#v1.7.2"
    }
  }
}
```

Please consider supporting this feature, especially since the patch is so small.
Test included.
