### PR TITLE
Spec: Only be one file per type in the main array

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ For now, `name`, `version`, `main`, and `dependencies` are the only properties t
 }
 ```
 
+There should only be at most one file per file type in the `main` list. So only one `.js` or `.css`.
+
 ### Installing dependencies
 
 Dependencies are installed locally via the `bower install` command. First they’re resolved to find conflicts. Then they’re downloaded and unpacked in a local subdirectory called `./components`, for example:


### PR DESCRIPTION
Previous discussion
- components/jquery#1
- sstephenson/sprockets#358

I think is was @fat's original intent of `main` with an Array, but I just want to clarify the spec.

For sprockets, I'd like to interpret the any main files to be automatically pulled in if you require the root package. This is basically the effect of creating a `main.js` and pointing it at whatever the main js is.

For something like qunit, it might have a js and css file.

``` json
"main":  ["./qunit.js", "./qunit.css"]
```

I'm also wondering how @yeoman could implement this better. Right now it just bombs if you the package uses an Array.

I'd expect `components/qunit/qunit.js` to be copied to `app/scripts/vendor/qunit.js` and `components/qunit/qunit.css` to `app/styles/vendor/qunit.css`.

/cc @maccman @fat @paulirish
