### PR TITLE
bower list --paths and --map should not throw

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -50,7 +50,7 @@ var generatePath = function (name, main) {
   if (typeof main == 'string') {
     return path.join(config.directory, name, main);
   } else {
-    var main = main.map(function (main) { return generatePath(name, main); });
+    var main = _.map(main, function (main) { return generatePath(name, main); });
     return main.length == 1 ? main[0] : main;
   }
 }

--- a/test/list.js
+++ b/test/list.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+var events = require('events');
+var list   = require('../lib/commands/list');
+
+describe('list', function () {
+
+  it('Should have line method', function () {
+    assert(!!list.line);
+  });
+
+  it('Should return an emiter', function () {
+    assert(list() instanceof events.EventEmitter);
+  });
+
+  it('returns path object with option --paths', function(next) {
+      list({paths: true}).on('data', function(data) {
+          assert(!!data);
+          next();
+      });
+  });
+
+  it('returns a map object with option -map', function(next) {
+      list({map: true}).on('data', function(data) {
+          assert(!!data);
+          next();
+      });
+  });
+});


### PR DESCRIPTION
Running `bower list --path` and `bower list --map` fails for me.
- I  attached a fix and tests to verify it. 
- The tests need to an installed package to fail (without the fix). 
