### PR TITLE
Make components directory configurable in component.json

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  directory: 'components', 
-  json:      'component.json'
+  json: 'component.json'
 }

--- a/lib/core/manager.js
+++ b/lib/core/manager.js
@@ -55,15 +55,17 @@ Manager.prototype.resolve = function () {
 };
 
 Manager.prototype.resolveLocal = function () {
-  glob('./' + config.directory + '/*', function (err, dirs) {
-    if (err) return this.emit('error', err);
-    dirs.forEach(function (dir) {
-      var name = path.basename(dir);
-      this.dependencies[name] = [];
-      this.dependencies[name].push(new Package(name, dir, this));
+  this.once('loadJSON', function () {
+    glob('./' + this.componentsDirectory + '/*', function (err, dirs) {
+      if (err) return this.emit('error', err);
+      dirs.forEach(function (dir) {
+        var name = path.basename(dir);
+        this.dependencies[name] = [];
+        this.dependencies[name].push(new Package(name, dir, this));
+      }.bind(this));
+      this.emit('resolveLocal');
     }.bind(this));
-    this.emit('resolveLocal');
-  }.bind(this));
+  }).loadJSON();
 };
 
 Manager.prototype.resolveEndpoints = function () {
@@ -90,6 +92,7 @@ Manager.prototype.loadJSON = function () {
       this.json    = JSON.parse(json);
       this.name    = this.json.name;
       this.version = this.json.version;
+      this.componentsDirectory = this.json.componentsDirectory || 'components';
       this.emit('loadJSON');
     }.bind(this));
   }.bind(this));

--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -90,6 +90,7 @@ var Package = function (name, endpoint, manager) {
   if (this.manager) {
     this.on('data',  this.manager.emit.bind(this.manager, 'data'));
     this.on('error', this.manager.emit.bind(this.manager, 'error'));
+    this.componentsDirectory = this.manager.componentsDirectory || 'components';
   }
 };
 
@@ -121,32 +122,36 @@ Package.prototype.lookup = function () {
 };
 
 Package.prototype.install = function () {
-  if (path.resolve(this.path) == this.localPath) return this.emit('install');
-  mkdirp(path.dirname(this.localPath), function (err) {
-    if (err) return this.emit('error', err);
-    rimraf(this.localPath, function (err) {
+  this.once('loadJSON', function(){
+    if (path.resolve(this.path) == this.localPath) return this.emit('install');
+    mkdirp(path.dirname(this.localPath), function (err) {
       if (err) return this.emit('error', err);
-      return fs.rename(this.path, this.localPath, function (err) {
-        if (!err) return this.cleanUpLocal();
-        fstream.Reader(this.path)
-          .on('error', this.emit.bind(this, 'error'))
-          .on('end', rimraf.bind(this, this.path, this.cleanUpLocal.bind(this)))
-          .pipe(
-            fstream.Writer({
-              type: 'Directory',
-              path: this.localPath
-            })
-          );
+      rimraf(this.localPath, function (err) {
+        if (err) return this.emit('error', err);
+        return fs.rename(this.path, this.localPath, function (err) {
+          if (!err) return this.cleanUpLocal();
+          fstream.Reader(this.path)
+            .on('error', this.emit.bind(this, 'error'))
+            .on('end', rimraf.bind(this, this.path, this.cleanUpLocal.bind(this)))
+            .pipe(
+              fstream.Writer({
+                type: 'Directory',
+                path: this.localPath
+              })
+            );
+        }.bind(this));
       }.bind(this));
     }.bind(this));
-  }.bind(this));
+  }).loadJSON();
 };
+
 Package.prototype.cleanUpLocal = function () {
   if (this.gitUrl) this.json.repository = { type: "git", url: this.gitUrl };
   if (this.assetUrl) this.json = this.generateAssetJSON();
   fs.writeFile(path.join(this.localPath, config.json), JSON.stringify(this.json, null, 2));
   rimraf(path.join(this.localPath, '.git'), this.emit.bind(this, 'install'));
 };
+
 Package.prototype.generateAssetJSON = function () {
   var semverParser = new RegExp('(' + semver.expressions.parse.toString().replace(/\$?\/\^?/g, '') + ')');
   return {
@@ -421,7 +426,7 @@ Package.prototype.fetchURL = function () {
 };
 
 Package.prototype.__defineGetter__('localPath', function () {
-  return path.join(process.cwd(), config.directory, this.name);
+  return path.join(process.cwd(), this.componentsDirectory, this.name);
 });
 
 module.exports = Package;


### PR DESCRIPTION
This is a proposed fix for #18, allowing the components directory location to be configured in component.json. As mentioned by others in the ticket, this is critical for our team's adoption of Bower as we have to control the location of vendor libraries more precisely.

Example usage:

``` json
{
  "name": "myProject",
  "version": "1.0.0",
  "main": "./path/to/main.css",
  "componentsDirectory": "foo/bar/baz",
  "dependencies": {
    "jquery": "~1.7.2"
  }
}
```

References and dependencies for `config.directory` were wrapped with an event listener for the JSON load, so as to wait for the directory location.

Let me know if this looks good; if so I'll update the readme.
