### PR TITLE
support filesystem-based repos

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -140,7 +140,7 @@ Package.prototype.resolve = function () {
   } else if (this.path) {
     this.copy();
   } else {
-    this.once('lookup', this.clone).lookup();
+    this.lookup();
   }
 
   return this;
@@ -150,8 +150,19 @@ Package.prototype.lookup = function () {
   source.lookup(this.name, function (err, url) {
     if (err) return this.emit('error', err);
     this.lookedUp = true;
-    this.gitUrl = url;
-    this.generateResourceId();
+    // check if the url returned is actually a local file path
+    // NOTE: this is a hack. what should probably be done is a re-resolution of the url resolved from the repo
+    // as done in constructor and resolve, decoupling lookup of metadata with download/copy of package contents
+    if (fileExists.sync(url)) {
+      // if so, perform a file copy
+      this.path = path.resolve(url);
+      this.copy();
+    } else {
+      // otherwise assume it's a git url
+      this.gitUrl = url;
+      this.generateResourceId();
+      this.clone();
+    }
     this.emit('lookup');
   }.bind(this));
 };

--- a/lib/core/source.js
+++ b/lib/core/source.js
@@ -6,9 +6,11 @@
 // http://opensource.org/licenses/MIT
 // ==========================================
 
+var path     = require('path');
 var request  = require('request');
 var _        = require('lodash');
 var config   = require('./config');
+var fileExists = require('../util/file-exists');
 
 var endpoint = config.endpoint + '/packages';
 
@@ -17,10 +19,18 @@ if (process.env.HTTP_PROXY) {
 }
 
 exports.lookup = function (name, callback) {
-  request.get(endpoint + '/' + encodeURIComponent(name), function (err, response, body) {
-    if (err || response.statusCode !== 200) return callback(err || new Error(name + ' not found'));
-    callback(err, body && JSON.parse(body).url);
-  });
+  var filePath = path.join(endpoint, name);
+  // check to see if this is a local file path
+  if (fileExists.sync(filePath)) {
+    // if so invoke callback immediately with package file path
+    callback(null, filePath);
+  } else { 
+    request.get(endpoint + '/' + encodeURIComponent(name), function (err, response, body) {
+      if (err || response.statusCode !== 200) return callback(err || new Error(name + ' not found'));
+      console.log(body);
+      callback(err, body && JSON.parse(body).url);
+    });
+  }
 };
 
 exports.register = function (name, url, callback) {


### PR DESCRIPTION
This is a spike of support for local filesystem-based repos.  This makes bower useful for internal modularization of private projects.  For example:

```
.bowerrc

{
  "directory" : "components",
  "json"      : "component.json",
  "endpoint"  : "../shared/"
}
```

This will allow direct install of components that exist locally on the filesystem:

`bower install private-shared-component`
or just
`bower install`

_Isn't this just a file copy task?_

Sure, but bower already provides an existing minimal component structure and development process.  In the future you may want to publish the private components and keep the same development workflow.  This saves hand rolling even more grunt config/js.

_bower already supports this: bower install /local/path_

Sure, but now you have to manually install each and every dependency.  This pull request makes `bower install` against a `component.json` work with a local repo.

_Caveats with this impl_

This spike is not particularly elegant.  It is just checking whether the composed url is a file system path (twice).  What is really called for is a decoupling of metadata lookup from url resolution: after the package metadata is looked up, it should be reparsed (the work in `Package` constructor) and re-resolved (the work of `Package.resolve`).  The resolve should then be able to determine the correct course of action (i.e. git clone, copy, asset download, etc.).  The way bower current implements it, it is just assumed any looked-up metadata will resolve to a git url (so I think there is a mismatch between the urls supported by command line and the urls supported in the component spec?).

I have not performed a more extensive refactoring in order to get feedback on this first.
