### PR TITLE
grammar fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install a package:
     bower install ./repos/jquery
 
 As you can see, packages can be installed by name, Git endpoint, GitHub shorthand, URL or local path.
-If you install and URL that is a zip or tar file, bower will automatically extract the contents of it.
+If you install an URL that is a zip or tar file, bower will automatically extract the contents of it.
 When tags are available in the endpoint, you can specify a [semver](http://semver.org/) tag to fetch concrete versions:
 
     bower install jquery#1.8.1


### PR DESCRIPTION
It could be 'an URL' or 'a URL' (depending on whether 'URL' is pronounced as an acronym, or its initials are spoken), but 'and URL' is definitely a mistake.  Since it is most likely just a typo, I'll assume 'an URL' was intended.
