### PR TITLE
Don't save dependency to component.json when it doesn't resolve

### DIFF
--- a/lib/util/save.js
+++ b/lib/util/save.js
@@ -14,8 +14,8 @@ var config = require('../core/config');
 
 function save(manager) {
   // Wait for the resolve event and then for the load json event
-  manager.on('resolve', function () {
-    manager.on('loadJSON', function () {
+  manager.on('resolve', function (resolved) {
+    if (resolved) manager.on('loadJSON', function () {
       manager.json.dependencies = manager.json.dependencies || {};
 
       // Only include the root packages


### PR DESCRIPTION
Fixes the case when install is called with --save and the dependency is saved to component.json even if it wasn't resolved. For example:

```
milos in test > bower install --save jquery
bower cloning git://github.com/components/jquery.git
bower cached git://github.com/components/jquery.git
bower fetching jquery
bower checking out jquery#1.9.1
bower copying /Users/milos/.bower/cache/jquery/cf68c4c4e7507c8d20fee7b5f26709d9
bower installing jquery#1.9.1
milos in test > bower install --save nonexistent-lib
bower error nonexistent-lib not found

There were errors, here's a summary of them:
- nonexistent-lib nonexistent-lib not found
milos in test > cat component.json
{
  "name": "test",
  "version": "0.0.0",
  "dependencies": {
    "jquery": "~1.9.1",
    "nonexistent-lib": "latest"
  }
}
```

This patch changes this to only update the component.json file if the dependency was successfully resolved.

I'm a Rubyist so if I did some style faux pas, let me know.

Cheers,
Miloš
