### PR TITLE
fix list --source listing non-main sources

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -53,25 +53,31 @@ var generatePath = function (name, main) {
   }
 };
 
+var mainTypes = ['main', 'scripts', 'styles', 'templates', 'images'];
+
 var buildSource = function (pkg, shallow) {
   var result = {};
 
   if (pkg) {
-    ['main', 'scripts', 'styles', 'templates', 'images'].forEach(function (type) {
+    mainTypes.forEach(function (type) {
       if (pkg.json[type]) result[type] = generatePath(pkg.name, pkg.json[type]);
     });
   }
 
   if (shallow) {
-    result.main = result.main      ? result.main
-                : result.scripts   ? result.scripts
-                : result.styles    ? result.styles
-                : result.templates ? result.templates
-                : result.images    ? result.images
-                : generatePath(pkg.name, '');
+    result.main = getMain(result) || generatePath(pkg.name, '');
   }
 
   return result;
+};
+
+var getMain = function (source) {
+  for (var i = 0, len = mainTypes.length; i < len; i += 1) {
+    var type = mainTypes[i];
+    if (source[type]) {
+      return source[type];
+    }
+  }
 };
 
 var shallowTree = function (packages, tree) {
@@ -127,7 +133,7 @@ var getDependencySrcs = function (list) {
   var dependency, main;
   for (var name in list) {
     dependency = list[name];
-    main = dependency.source && dependency.source.main;
+    main = dependency.source && getMain(dependency.source);
 
     if (dependency.dependencies) {
       var depSrcs = getDependencySrcs(dependency.dependencies);

--- a/test/assets/package-complex-a1/component.json
+++ b/test/assets/package-complex-a1/component.json
@@ -1,7 +1,7 @@
 {
   "name": "a1",
   "version": "0.0.1",
-  "main": [
+  "scripts": [
     "a1.js"
   ],
   "dependencies": {

--- a/test/assets/package-complex-c/component.json
+++ b/test/assets/package-complex-c/component.json
@@ -1,7 +1,7 @@
 {
   "name": "c",
   "version": "0.0.1",
-  "main": "c.js",
+  "styles": "c.css",
   "dependencies": {
   }
 }

--- a/test/list.js
+++ b/test/list.js
@@ -78,7 +78,7 @@ describe('list', function () {
             ],
             b: ['components/b/b.js', 'components/b/b.html'],
             b1: ['components/b1/b1.js', 'components/b1/b1.css'],
-            c: 'components/c/c.js'
+            c: 'components/c/c.css'
           });
 
           next();
@@ -141,13 +141,13 @@ describe('list', function () {
               'components/a2/a2.js',
               'components/a/a.js',
               'components/b1/b1.js',
-              'components/b/b.js',
-              'components/c/c.js'
+              'components/b/b.js'
             ],
             '.css': [
               'components/a2/a2.css',
               'components/a/a.css',
-              'components/b1/b1.css'
+              'components/b1/b1.css',
+              'components/c/c.css'
             ],
             '.html': [ 'components/a2/a2.html', 'components/b/b.html' ]
           });


### PR DESCRIPTION
I ran into a bug when I had [normalize-css](https://github.com/necolas/normalize.css) as a dependency. Its component.json does not use `main` but `"styles": ["normalize.css"]`. `bower list --sources` missed listing the file.
