### PR TITLE
Remove use of `grey` from templates

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -33,12 +33,12 @@ if (~cmdList.indexOf(command = options.argv.remain && options.argv.remain.shift(
 
 bower.commands[bower.command || 'help'].line(input)
   .on('data', function (data) {
-    if (data) console.log(data);
+    if (data) process.stdout.write(data);
   })
   .on('end', function (data) {
-    if (data) console.log(data);
+    if (data) process.stdout.write(data);
   })
   .on('error', function (err)  {
     if (options.verbose) throw err;
-    else console.log(template('error', { message: err.message }, true));
+    else process.stdout.write(template('error', { message: err.message }, true));
   });

--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -680,7 +680,7 @@ Package.prototype.describeTag = function () {
   });
 
   cp.on('close', function (code) {
-    if (code === 128) tag = 'unspecified'.grey; // Not a git repo
+    if (code === 128) tag = 'unspecified'; // Not a git repo
     this.emit('describeTag', tag.replace(/\n$/, ''));
   }.bind(this));
 };

--- a/lib/util/hogan-colors.js
+++ b/lib/util/hogan-colors.js
@@ -18,10 +18,9 @@ module.exports = hogan.Template.prototype.renderWithColors = function (context, 
 
   context = _.extend({
     yellow : function (s) { return s.yellow; },
-    green  : function (s) { return s.green;  },
-    cyan   : function (s) { return s.cyan;   },
-    grey   : function (s) { return s.grey;   },
-    red    : function (s) { return s.red;    },
+    green  : function (s) { return s.green; },
+    cyan   : function (s) { return s.cyan; },
+    red    : function (s) { return s.red; },
     white  : function (s) { return s.white; }
   }, context);
   return this.ri([context], partials || {}, indent);

--- a/templates/action.mustache
+++ b/templates/action.mustache
@@ -1,1 +1,1 @@
-bower {{#cyan}}{{{name}}}{{/cyan}} {{#grey}}{{{shizzle}}}{{/grey}}
+bower {{#cyan}}{{{name}}}{{/cyan}} {{{shizzle}}}

--- a/templates/complete.mustache
+++ b/templates/complete.mustache
@@ -1,1 +1,1 @@
-bower {{#cyan}}{{{command}}}{{/cyan}} {{#grey}}complete{{/grey}}
+bower {{#cyan}}{{{command}}}{{/cyan}} complete

--- a/templates/error-summary.mustache
+++ b/templates/error-summary.mustache
@@ -3,6 +3,6 @@
 {{#errors}}
 - {{#red}}{{{pkg.name}}}{{/red}} {{{error.message}}}
 {{#error.details}}
-{{#grey}}{{{error.details}}}{{/grey}}
+{{{error.details}}}
 {{/error.details}}
 {{/errors}}

--- a/templates/error.mustache
+++ b/templates/error.mustache
@@ -1,1 +1,1 @@
-bower {{#red}}error{{/red}} {{#grey}}{{{message}}}{{/grey}}
+bower {{#red}}error{{/red}} {{{message}}}

--- a/templates/help-cache-clean.mustache
+++ b/templates/help-cache-clean.mustache
@@ -2,7 +2,7 @@
 Usage:
 
     {{#cyan}}bower{{/cyan}} cache-clean
-    {{#cyan}}bower{{/cyan}} cache-clean {{#grey}}<pkg>{{/grey}}
+    {{#cyan}}bower{{/cyan}} cache-clean <pkg>
 
 Options:
 
@@ -10,7 +10,7 @@ Options:
 
 Can specify one or more:
 
-    {{#cyan}}bower{{/cyan}} cache-clean {{#grey}}package other-package{{/grey}}
+    {{#cyan}}bower{{/cyan}} cache-clean package other-package
 
 Description:
 

--- a/templates/help-info.mustache
+++ b/templates/help-info.mustache
@@ -1,7 +1,7 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} info {{#grey}}<pkg>{{/grey}}
+    {{#cyan}}bower{{/cyan}} info <pkg>
 
 Options:
 

--- a/templates/help-init.mustache
+++ b/templates/help-init.mustache
@@ -5,7 +5,7 @@ Usage:
 
 Options:
 
-    {{#yellow}}--no-color{{/yellow}}     - Do not print colors
+    {{#yellow}}--no-color{{/yellow}} - Do not print colors
 
 Description:
 

--- a/templates/help-install.mustache
+++ b/templates/help-install.mustache
@@ -2,9 +2,9 @@
 Usage:
 
     {{#cyan}}bower{{/cyan}} install
-    {{#cyan}}bower{{/cyan}} install {{#grey}}<folder>{{/grey}}
-    {{#cyan}}bower{{/cyan}} install {{#grey}}<pkg>{{/grey}}
-    {{#cyan}}bower{{/cyan}} install {{#grey}}<pkg>#<version>{{/grey}}
+    {{#cyan}}bower{{/cyan}} install <folder>
+    {{#cyan}}bower{{/cyan}} install <pkg>
+    {{#cyan}}bower{{/cyan}} install <pkg>#<version>
 
 Options:
 
@@ -17,8 +17,8 @@ Options:
 
 Can specify one or more:
 
-    {{#cyan}}bower{{/cyan}} install {{#grey}}./foo/package git://example.com#1.0.2{{/grey}}
+    {{#cyan}}bower{{/cyan}} install ./foo/package git://example.com#1.0.2
 
 Description:
 
-    Installs a browser package locally into a {{#grey}}{{{directory}}}{{/grey}} directory
+    Installs a browser package locally into a {{{directory}}} directory

--- a/templates/help-link.mustache
+++ b/templates/help-link.mustache
@@ -2,7 +2,7 @@
 Usage:
 
     {{#cyan}}bower{{/cyan}} link
-    {{#cyan}}bower{{/cyan}} link {{#grey}}<pkg>{{/grey}}
+    {{#cyan}}bower{{/cyan}} link <pkg>
 
 Options:
 
@@ -13,8 +13,8 @@ Description:
     The link functionality allows developers to easily test their packages.
     Linking is a two-step process.
 
-    Using {{#grey}}bower link{{/grey}} in a project folder will create a global link.
-    Then, in some other package, {{#grey}}bower link <pkg>{{/grey}} will create a link in the components folder
+    Using 'bower link' in a project folder will create a global link.
+    Then, in some other package, 'bower link <pkg>' will create a link in the components folder
     pointing to the previously created link.
 
     This allows to easily test a package because changes will be reflected immediately.

--- a/templates/help-lookup.mustache
+++ b/templates/help-lookup.mustache
@@ -1,7 +1,7 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} lookup {{#grey}}<package>{{/grey}}
+    {{#cyan}}bower{{/cyan}} lookup <package>
 
 Options:
 

--- a/templates/help-register.mustache
+++ b/templates/help-register.mustache
@@ -1,7 +1,7 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} register {{#cyan}}<name>{{/cyan}} {{#grey}}<url>{{/grey}}
+    {{#cyan}}bower{{/cyan}} register {{#cyan}}<name>{{/cyan}} <url>
 
 Options:
 

--- a/templates/help-search.mustache
+++ b/templates/help-search.mustache
@@ -2,7 +2,7 @@
 Usage:
 
     {{#cyan}}bower{{/cyan}} search
-    {{#cyan}}bower{{/cyan}} search {{#grey}}<name>{{/grey}}
+    {{#cyan}}bower{{/cyan}} search <name>
 
 Options:
 

--- a/templates/help-uninstall.mustache
+++ b/templates/help-uninstall.mustache
@@ -1,7 +1,7 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} uninstall {{#grey}}<package>{{/grey}}
+    {{#cyan}}bower{{/cyan}} uninstall <package>
 
 Options:
 
@@ -13,8 +13,8 @@ Options:
 
 Can specify one or more:
 
-    {{#cyan}}bower{{/cyan}} uninstall {{#grey}}jquery jquery-ui{{/grey}}
+    {{#cyan}}bower{{/cyan}} uninstall jquery jquery-ui
 
 Description:
 
-    Uninstalls a browser package locally from your {{#grey}}{{{directory}}}{{/grey}} directory
+    Uninstalls a browser package locally from your {{{directory}}} directory

--- a/templates/help-update.mustache
+++ b/templates/help-update.mustache
@@ -2,7 +2,7 @@
 Usage:
 
     {{#cyan}}bower{{/cyan}} update
-    {{#cyan}}bower{{/cyan}} update {{#grey}}<package>{{/grey}}
+    {{#cyan}}bower{{/cyan}} update <package>
 
 Options:
 

--- a/templates/help.mustache
+++ b/templates/help.mustache
@@ -1,7 +1,7 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} <command> {{#grey}}<options>{{/grey}}
+    {{#cyan}}bower{{/cyan}} <command> <options>
 
 Options:
 
@@ -13,8 +13,8 @@ Commands:
 
 Example:
 
-    {{#grey}}${{/grey}} {{#cyan}}bower{{/cyan}} install {{#grey}}bootstrap spine jquery{{/grey}}
+    $ {{#cyan}}bower{{/cyan}} install bootstrap spine jquery
 
 General Help:
 
-    {{#grey}}http://git.io/bower{{/grey}}
+    http://git.io/bower

--- a/templates/info.mustache
+++ b/templates/info.mustache
@@ -1,4 +1,4 @@
-{{#pkg}}{{#cyan}}{{{name}}}{{/cyan}} {{#grey}}{{{url}}}{{/grey}}{{/pkg}}
+{{#pkg}}{{#cyan}}{{{name}}}{{/cyan}} {{{url}}}{{/pkg}}
 
   Versions:
   {{#versions}}

--- a/templates/link.mustache
+++ b/templates/link.mustache
@@ -1,1 +1,1 @@
-bower {{#cyan}}link{{/cyan}} {{#grey}}{{{dest}}}{{/grey}} > {{#grey}}{{{src}}}{{/grey}}
+bower {{#cyan}}link{{/cyan}} {{{dest}}} > {{{src}}}

--- a/templates/lookup.mustache
+++ b/templates/lookup.mustache
@@ -1,1 +1,1 @@
-{{#cyan}}{{{name}}}{{/cyan}} {{#grey}}{{{url}}}{{/grey}}
+{{#cyan}}{{{name}}}{{/cyan}} {{{url}}}

--- a/templates/register.mustache
+++ b/templates/register.mustache
@@ -1,1 +1,1 @@
-registered {{#cyan}}{{{name}}}{{/cyan}} to {{#grey}}{{{url}}}{{/grey}}
+registered {{#cyan}}{{{name}}}{{/cyan}} to {{{url}}}

--- a/templates/search.mustache
+++ b/templates/search.mustache
@@ -1,5 +1,5 @@
 Search results:
 
 {{#results}}
-  - {{#cyan}}{{{name}}}{{/cyan}} {{#grey}}{{{url}}}{{/grey}}
+    {{#cyan}}{{{name}}}{{/cyan}} {{{url}}}
 {{/results}}

--- a/templates/suggestions.mustache
+++ b/templates/suggestions.mustache
@@ -1,5 +1,5 @@
 Sorry, {{#red}}{{{name}}}{{/red}} wasn't found. Did you mean:
 
 {{#packages}}
-  {{#cyan}}{{{name}}}{{/cyan}} - {{#grey}}{{{url}}}{{/grey}}
+  {{#cyan}}{{{name}}}{{/cyan}} - {{{url}}}
 {{/packages}}

--- a/templates/tree-branch.mustache
+++ b/templates/tree-branch.mustache
@@ -1,1 +1,1 @@
-{{#version}}{{#cyan}}{{{package}}}{{/cyan}}#{{{version}}}{{/version}}{{^version}}{{#yellow}}{{{package}}} - unknown version{{/yellow}}{{/version}}{{#upgrade}}{{#grey}} ({{{upgrade}}} now available){{/grey}}{{/upgrade}}
+{{#version}}{{#cyan}}{{{package}}}{{/cyan}}#{{{version}}}{{/version}}{{^version}}{{#yellow}}{{{package}}} - unknown version{{/yellow}}{{/version}}{{#upgrade}} ({{{upgrade}}} now available){{/upgrade}}

--- a/templates/warn.mustache
+++ b/templates/warn.mustache
@@ -1,1 +1,1 @@
-bower {{#yellow}}warn{{/yellow}} {{#grey}}{{{message}}}{{/grey}}
+bower {{#yellow}}warn{{/yellow}} {{{message}}}

--- a/templates/warning-mismatch.mustache
+++ b/templates/warning-mismatch.mustache
@@ -1,2 +1,2 @@
-{{#yellow}}mismatch{{/yellow}} {{#grey}}The version specified in the{{/grey}} {{{json}}} {{#grey}}of package {{/grey}}{{{name}}} {{#grey}}mismatches the tag ({{/grey}}{{#red}}{{{tag}}}{{/red}} {{#grey}}vs{{/grey}} {{#red}}{{{version}}}{{/red}}{{#grey}}){{/grey}}
-{{#yellow}}mismatch{{/yellow}} {{#grey}}You should report this problem to the package author{{/grey}}
+{{#yellow}}mismatch{{/yellow}} The version specified in the {{{json}}} of package {{{name}}} mismatches the tag ({{#red}}{{{tag}}}{{/red}} vs {{#red}}{{{version}}}{{/red}})
+{{#yellow}}mismatch{{/yellow}} You should report this problem to the package author

--- a/templates/warning-uninstall.mustache
+++ b/templates/warning-uninstall.mustache
@@ -1,1 +1,1 @@
-{{#red}}conflict{{/red}} {{#cyan}}{{{packageName}}}{{/cyan}} depends on {{#grey}}{{{conflictName}}}{{/grey}}
+{{#red}}conflict{{/red}} {{#cyan}}{{{packageName}}}{{/cyan}} depends on {{{conflictName}}}


### PR DESCRIPTION
This is a long standing issue where the `grey` color from the `colors`
package is invisible in some terminal color schemes, most notably
Solarized Dark.

The changeset also replaces `console.log()` with
`process.stdout.write()` in the main `bower` bin file. This is because
some of the mustache templates didn't have a new line at the end of the
file (something that most editors will automatically insert). Now they
all consistently have an EOF new line. But `console.log()` adds a
trailing new line, so switch to `process.stdout.write()`.
