### PR TITLE
Small improvement to default `help`

### DIFF
--- a/templates/help.mustache
+++ b/templates/help.mustache
@@ -1,20 +1,26 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} <command> <options>
+    {{#cyan}}bower{{/cyan}} <command> [<args>] [<options>]
+
+Commands:
+
+    cache-clean    Clean the Bower cache, or the specified package caches
+    completion     Tab Completion for Bower
+    help           Display help information about Bower
+    info           Version info and description of a particular package
+    init           Interactively create a component.json file
+    install        Install a package locally
+    link           Symlink a package folder
+    list, ls       List all installed packages
+    lookup         Look up a package URL by name
+    register       Register a package
+    search         Search for a package by name
+    uninstall      Remove a package
+    update         Update a package
 
 Options:
 
     {{#yellow}}--no-color{{/yellow}} - Do not print colors (available in all commands)
 
-Commands:
-
-    {{{commands}}}
-
-Example:
-
-    $ {{#cyan}}bower{{/cyan}} install bootstrap spine jquery
-
-General Help:
-
-    http://git.io/bower
+See 'bower help <command>' for more information on a specific command.


### PR DESCRIPTION
One small, first step towards improving the CLI help / documentation.
- Include correct usage grammar.
- List commands before options first.
- Include brief description of commands.
- Remove example.
- Indicate how to access help for individual comamnds.
- Remove link to GitHub as the CLI help is superior.
