### PR TITLE
Prefer installing into name as declared by component.json

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -224,7 +224,9 @@ Package.prototype.install = function () {
 
 Package.prototype.cleanUpLocal = function () {
   this.once('readLocalConfig', function () {
-    this.json.name    = this.name;
+    // Set implicit json package name
+    if (!this.json.name) this.json.name = this.name;
+
     this.json.version = this.commit ? '0.0.0' : this.version || '0.0.0';
 
     // Detect commit and save it in the json for later use


### PR DESCRIPTION
Had to revert #268, sorry. Turned out changing the `Package#name` property broke a ton of resolve code.

This is a more targeted alternative fix that only affects the installation directory.

/cc @satazor @sindresorhus 
