### PR TITLE
Allow config variables to be overridden by environment variables

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -58,7 +58,11 @@ if (fileExists(localFile)) {
 Object.keys(process.env).forEach(function (key) {
   if (key.indexOf('BOWER_CONFIG_') === 0) {
     var configVar = key.substring(13).toLowerCase();
-    config[configVar] = process.env[key];
+    var configVal = process.env[key];
+    if (configVar === 'searchpath') {
+      configVal = configVal.split(' ');
+    }
+    config[configVar] = configVal;
   }
 });
 


### PR DESCRIPTION
Similar to https://npmjs.org/doc/config.html#Environment-Variables this change allows configuration settings to be overridden by environment variables.  Environment variables starting with `BOWER_CONFIG_` will be merged into the config.

My use case for this is building projects which use Bower with Jenkins.  If more than one build is running at the same time they both try to write to the cache directory which can produce git locking errors.  It seems cleaner to me to just add an environment variable to the build rather than adding a `.bowerrc` file which would affect all developers as well.
