### PR TITLE
bower command should exit with return code 1 on error

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -40,5 +40,8 @@ bower.commands[bower.command || 'help'].line(input)
   })
   .on('error', function (err)  {
     if (options.verbose) throw err;
-    else process.stdout.write(template('error', { message: err.message }, true));
+    else {
+      process.stdout.write(template('error', { message: err.message }, true));
+      process.exit(1);
+    }
   });


### PR DESCRIPTION
This is greatly simplifies usage of bower command in shell scripts or in Makefiles cause now it can report back to environment if installation or other action has failed.
