### PR TITLE
Add cyan color to <url> parameter

### DIFF
--- a/templates/help-register.mustache
+++ b/templates/help-register.mustache
@@ -1,7 +1,7 @@
 
 Usage:
 
-    {{#cyan}}bower{{/cyan}} register {{#cyan}}<name>{{/cyan}} <url>
+    {{#cyan}}bower{{/cyan}} register {{#cyan}}<name>{{/cyan}} {{#cyan}}<url>{{/cyan}}
 
 Options:
 


### PR DESCRIPTION
This fixes the issue where the <url> parameter was not being shown unless you
added --no-color to the call. On some shells, <url> is the same color as the
background, but additionally the change of color should make this particular
command a bit easier to read, and clearer as to which params are required.

Before (v0.8.5):

![Screen Shot 2013-03-15 at 1 32 20 PM](https://f.cloud.github.com/assets/113026/264680/74b498c2-8d96-11e2-864e-fa192a11a75f.png)

After (tubbo:master):

![Screen Shot 2013-03-15 at 1 33 48 PM](https://f.cloud.github.com/assets/113026/264681/82c44926-8d96-11e2-8c05-67584524d4a7.png)
