### PR TITLE
Bower should use new unzip npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "read-package-json": "~0.1.8",
     "stable": "~0.1.2",
     "rc": "~0.0.6",
-    "unzip": "0.1.4",
+    "unzip": "0.1.5",
     "tar": "~0.1.13",
     "promptly": "~0.1.0",
     "abbrev": "~1.0.4"


### PR DESCRIPTION
Node.js v0.10.0 made some changes to the way pullstream works which broke unzip. New unzip uses new pullstream.
