### PR TITLE
Consistent package cache path

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -115,7 +115,7 @@ var Package = function (name, endpoint, manager) {
     this.on('data',  this.manager.emit.bind(this.manager, 'data'));
     this.on('error', function (err, origin) {
       // Unlock the unit of work automatically on error (only if the error is from this package)
-      if (!origin && this.unitWork.isLocked(this.name)) this.unitWork.unlock(this.name, this);
+      if (!origin && this.unitWork.isLocked(this.cacheName)) this.unitWork.unlock(this.cacheName, this);
       // Propagate the error event to the parent package/manager
       this.manager.emit('error', err, origin || this);
     }.bind(this));
@@ -134,9 +134,9 @@ Package.prototype.constructor = Package;
 Package.prototype.resolve = function () {
   // Ensure that nobody is resolving the same dep at the same time
   // If there is, we wait for the unlock event
-  if (this.unitWork.isLocked(this.name)) return this.unitWork.on('unlock', this.waitUnlock);
+  if (this.unitWork.isLocked(this.cacheName)) return this.unitWork.on('unlock', this.waitUnlock);
 
-  var data = this.unitWork.retrieve(this.name);
+  var data = this.unitWork.retrieve(this.cacheName);
   if (data) {
     // Check if this exact package is the last resolved one
     // If so, we copy the resolved result and we don't need to do anything else
@@ -148,7 +148,7 @@ Package.prototype.resolve = function () {
   }
 
   // If not, we lock and resolve it
-  this.unitWork.lock(this.name, this);
+  this.unitWork.lock(this.cacheName, this);
 
   if (this.assetUrl) {
     this.download();
@@ -175,7 +175,7 @@ Package.prototype.lookup = function () {
 
 Package.prototype.install = function () {
   // Only print the installing action if this package has been resolved
-  if (this.unitWork.retrieve(this.name)) {
+  if (this.unitWork.retrieve(this.cacheName)) {
     template('action', { name: 'installing', shizzle: this.name + (this.version ? '#' + this.version : '') })
       .on('data', this.emit.bind(this, 'data'));
   }
@@ -390,10 +390,10 @@ Package.prototype.loadJSON = function () {
         var cleanedTag;
         if (this.tag && (cleanedTag = semver.clean(this.tag)) && cleanedTag !== this.version) {
           // Only print the warning once
-          if (!this.unitWork.retrieve('mismatch#' + this.name + '_' + cleanedTag)) {
-            template('warning-mismatch', { name: this.name, json: this.localConfig.json, tag: cleanedTag, version: this.version || 'N/A' })
+          if (!this.unitWork.retrieve('mismatch#' + this.cacheName + '_' + cleanedTag)) {
+            template('warning-mismatch', { name: this.cacheName, json: this.localConfig.json, tag: cleanedTag, version: this.version || 'N/A' })
               .on('data', this.emit.bind(this, 'data'));
-            this.unitWork.store('mismatch#' + this.name + '_' + cleanedTag, true);
+            this.unitWork.store('mismatch#' + this.cacheName + '_' + cleanedTag, true);
           }
           // Assume the tag
           this.version = cleanedTag;
@@ -559,8 +559,8 @@ Package.prototype.getDeepDependencies = function (result) {
 };
 
 Package.prototype.saveUnit = function () {
-  this.unitWork.store(this.name, this.serialize(), this);
-  this.unitWork.unlock(this.name, this);
+  this.unitWork.store(this.cacheName, this.serialize(), this);
+  this.unitWork.unlock(this.cacheName, this);
   this.addDependencies();
 };
 
@@ -595,10 +595,10 @@ Package.prototype.cache = function () {
   // If the force options is true, we need to erase from the cache
   // Be aware that a similar package might already flushed it
   // To prevent that we check the unit of work storage
-  if (this.opts.force && !this.unitWork.retrieve('flushed#' + this.name + '_' + this.resourceId)) {
+  if (this.opts.force && !this.unitWork.retrieve('flushed#' + this.cacheName + '_' + this.resourceId)) {
     rimraf(this.path, function (err) {
       if (err) return this.emit('error', err);
-      this.unitWork.store('flushed#' + this.name + '_' + this.resourceId, true);
+      this.unitWork.store('flushed#' + this.cacheName + '_' + this.resourceId, true);
       this.cache();
     }.bind(this));
     return this;
@@ -821,11 +821,7 @@ Package.prototype.unserialize = function (obj) {
 
 Package.prototype.generateResourceId = function () {
   this.resourceId = crypto.createHash('md5').update(this.gitUrl).digest('hex');
-
-  // Always generate cache name from the git url
-  // this.name maybe a guessed name which can change after loadJSON
-  var name = path.basename(this.gitUrl).replace(/(\.git)?(#.*)?$/, '');
-  this.gitPath = path.join(config.cache, name, this.resourceId);
+  this.gitPath = path.join(config.cache, this.cacheName, this.resourceId);
 };
 
 Package.prototype.resolveShorthand = function (shorthand, path) {
@@ -839,6 +835,14 @@ Package.prototype.resolveShorthand = function (shorthand, path) {
     endpoint: path
   });
 };
+
+Package.prototype.__defineGetter__('cacheName', function () {
+  if (this.gitUrl) {
+    return path.basename(this.gitUrl).replace(/(\.git)?(#.*)?$/, '');
+  } else {
+    return this.name;
+  }
+});
 
 Package.prototype.__defineGetter__('localPath', function () {
   return path.join(process.cwd(), config.directory, this.name);


### PR DESCRIPTION
Moves towards decoupling the package source cache path location of the package name instead. The package name maybe guessed or overridden. This causes issues when given a local package is referencing back to the cached path and is checked for updates.

Related to #331.

/cc @satazor 
