### PR TITLE
Updated unzip to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "read-package-json": "~0.1.8",
     "stable": "~0.1.2",
     "rc": "~0.0.6",
-    "unzip": "0.1.4",
+    "unzip": "0.1.6",
     "tar": "~0.1.13",
     "promptly": "~0.1.0",
     "abbrev": "~1.0.4"


### PR DESCRIPTION
There were problems with node-unzip 0.1.4 and node 0.10.0. When installing a
component that requires unzip, installation would terminate with error message:

```
TypeError: listener must be a function
    at TypeError (<anonymous>)
    at Parse.EventEmitter.once (events.js:171:11)
    at Extract._write (/Users/satazor/Work/twitter/bower/node_modules/unzip/lib/extract.js:59:23)
    at doWrite (_stream_writable.js:211:10)
    at writeOrBuffer (_stream_writable.js:201:5)
    at Extract.Writable.write (_stream_writable.js:172:11)
    at write (_stream_readable.js:547:24)
    at flow (_stream_readable.js:556:7)
    at ReadStream.pipeOnReadable (_stream_readable.js:588:5)
    at ReadStream.EventEmitter.emit (events.js:92:17)
```

These problems have been fixed in 0.1.6. You can read more about this discussion
at https://github.com/nearinfinity/node-unzip/issues/20#issuecomment-15752755.
