### PR TITLE
Use --depth 1 when cloning git repos (#217)

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -582,8 +582,8 @@ Package.prototype.addDependencies = function () {
       var endpoint = dependencies[name];
       var pkg = new Package(name, endpoint, this);
       pkg.once('resolve', function () {
-        this.dependencies[pkg.name] = pkg
-        callback()
+        this.dependencies[pkg.name] = pkg;
+        callback();
       }.bind(this)).resolve();
     }.bind(this);
   }.bind(this));
@@ -618,40 +618,40 @@ Package.prototype.cache = function () {
     return this;
   }
 
-  mkdirp(config.cache, function (err) {
-    if (err) return this.emit('error', err);
-    fileExists(this.path, function (exists) {
-      if (exists) {
-        template('action', { name: 'cached', shizzle: this.gitUrl }).on('data', this.emit.bind(this, 'data'));
-        return this.emit('cache');
-      }
-      template('action', { name: 'caching', shizzle: this.gitUrl }).on('data', this.emit.bind(this, 'data'));
-      var url = this.gitUrl;
-      if (config.proxy) {
-        url = url.replace(/^git:/, 'https:');
-      }
+  this.chooseTag(function (tag) {
+    mkdirp(config.cache, function (err) {
+      if (err) return this.emit('error', err);
+      fileExists(this.path, function (exists) {
+        if (exists) {
+          template('action', { name: 'cached', shizzle: this.gitUrl }).on('data', this.emit.bind(this, 'data'));
+          return this.once('fetch', function () {
+            return this.emit('cache');
+          }).fetch(tag);
+        }
+        template('action', { name: 'caching', shizzle: this.gitUrl }).on('data', this.emit.bind(this, 'data'));
+        var url = this.gitUrl;
+        if (config.proxy) {
+          url = url.replace(/^git:/, 'https:');
+        }
 
-      mkdirp(this.path, function (err) {
-        if (err) return this.emit('error', err);
+        mkdirp(this.path, function (err) {
+          if (err) return this.emit('error', err);
 
-        var cp = git(['clone', url, this.path], null, this);
-        cp.on('close', function (code) {
-          if (code) return;
-          this.emit('cache');
+          var cp = git(['clone', '--depth', 1, '-b', tag, url, this.path], null, this);
+          cp.on('close', function (code) {
+            if (code) return;
+            this.emit('cache');
+          }.bind(this));
         }.bind(this));
       }.bind(this));
     }.bind(this));
   }.bind(this));
 };
 
-Package.prototype.checkout = function () {
-  template('action', { name: 'fetching', shizzle: this.name })
-    .on('data', this.emit.bind(this, 'data'));
-
+Package.prototype.chooseTag = function (callback) {
   this.once('versions', function (versions) {
     if (!versions.length) {
-      this.emit('checkout');
-      this.loadJSON();
+      callback();
     }
 
     // If tag is specified, try to satisfy it
@@ -672,10 +672,19 @@ Package.prototype.checkout = function () {
     }
 
     // Use latest version
-    this.tag = versions[0];
-    if (!semver.valid(this.tag)) this.commit = this.tag;  // If the version is not valid, then its a commit
+    callback(versions[0]);
+  }).versions();
+};
 
-    if (this.tag) {
+Package.prototype.checkout = function () {
+  template('action', { name: 'fetching', shizzle: this.name })
+    .on('data', this.emit.bind(this, 'data'));
+
+  this.chooseTag(function (tag) {
+    if (tag) {
+      this.tag = tag;
+      if (!semver.valid(this.tag)) this.commit = this.tag;  // If the version is not valid, then its a commit
+
       template('action', {
         name: 'checking out',
         shizzle: this.name + '#' + this.tag
@@ -691,8 +700,11 @@ Package.prototype.checkout = function () {
           this.loadJSON();
         }.bind(this));
       }.bind(this));
+    } else {
+      this.emit('checkout');
+      this.loadJSON();
     }
-  }).versions();
+  }.bind(this));
 };
 
 Package.prototype.describeTag = function () {
@@ -759,23 +771,22 @@ Package.prototype.versions = function () {
     cp.on('close', function (code) {
       if (code) return;
       versions = _.compact(versions.split('\n'));
+      versionCache[this.gitUrl] = versions;
       this.emit('versions', versions);
     }.bind(this));
   }.bind(this));
 };
 
-Package.prototype.fetch = function () {
-  fileExists(this.gitPath, function (exists) {
+Package.prototype.fetch = function (tag) {
+  fileExists(this.path, function (exists) {
     if (!exists) return this.emit('error', new Error('Unable to fetch package ' + this.name + ' (if the cache was deleted, run install again)'));
 
-    var cp = git(['fetch', '--prune'], { cwd: this.gitPath }, this);
+    var refspec = '+refs/tags/' + tag + ':refs/tags/' + tag;
+
+    var cp = git(['fetch', '--prune', 'origin', refspec], { cwd: this.path }, this);
     cp.on('close', function (code) {
       if (code) return;
-      cp = git(['reset', '--hard', this.gitUrl ? 'origin/HEAD' : 'HEAD'], { cwd: this.gitPath }, this);
-      cp.on('close', function (code) {
-        if (code) return;
-        this.emit('fetch');
-      }.bind(this));
+      this.emit('fetch');
     }.bind(this));
   }.bind(this));
 };


### PR DESCRIPTION
This PR actually includes the changes made in #379 as they were needed to make this work.

If you use a version of git < 1.8 the tests fail because shallow clones will still include most tags. It doesn't break anything, but it does mean that you don't get much benefit. I'm not sure if that matters but I thought I should point it out!
