### PR TITLE
Warnings should be on stderr, not stdout

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -51,7 +51,7 @@ bower.commands[bower.command || 'help'].line(input)
     if (data) process.stdout.write(data);
   })
   .on('warn', function (warning)  {
-    process.stdout.write(template('warn', { message: warning }, true));
+    process.stderr.write(template('warn', { message: warning }, true));
   })
   .on('error', function (err)  {
     if (options.verbose) throw err;


### PR DESCRIPTION
I made a mistake when setting up the deprecation warnings. I meant for them to be on stderr not stdout.
