### PR TITLE
Fix the tests to account for upgraded dependencies of fixtures

### DIFF
--- a/test/package.js
+++ b/test/package.js
@@ -637,7 +637,7 @@ describe('package', function () {
 
     pkg.on('resolve', function () {
       // jQuery will get resolved twice as it is a dependency of both explicit dependencies.
-      assert.equal(warn.length, 4);
+      assert.equal(warn.length, 3);
       next();
     });
 


### PR DESCRIPTION
One of the test fixtures requires jquery with any version, so no longer gives the deprecation warning for that dep.
