### PR TITLE
Issue #469

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -45,6 +45,7 @@ try {
     endpoint            : 'https://bower.herokuapp.com',
     directory           : 'components',
     proxy               : proxy,
+    force_https         : false,
     shorthand_resolver  : 'git://github.com/{{{ endpoint }}}.git'
   });
 } catch (e) {

--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -652,6 +652,9 @@ Package.prototype.cache = function () {
       mkdirp(this.path, function (err) {
         if (err) return this.emit('error', err);
 
+        if (config.force_https){
+          url = url.replace(/^git:/, 'https:');
+        }
         var cp = git(['clone', url, this.path], null, this);
         cp.on('close', function (code) {
           if (code) return;


### PR DESCRIPTION
In some situations, for example, Jenkins integration, the git command line which forces https:// instead of git:// urls, doesn't works as it would.

This pull request, create a configuration option called force_https (boolean) into .bowerrc file, that forces the url string replacement to change git:// to https://
