### PR TITLE
fix parse for multiple dots in local js file

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -69,7 +69,7 @@ var Package = function (name, endpoint, manager) {
       this.tag = endpoint;
       this.explicitName = false;
 
-    } else if (/^[\.\/~]\.?[^.]*\.(js|css)/.test(endpoint) && fs.statSync(endpoint).isFile()) {
+    } else if (/^[\.\/~].*[^.]*\.(js|css)$/.test(endpoint) && fs.statSync(endpoint).isFile()) {
       this.path      = path.resolve(endpoint);
       this.assetType = path.extname(endpoint);
 


### PR DESCRIPTION
The regular expression `/^[\.\/~]\.?[^.]*\.(js|css)/` was not picking up local js files like `/somepackage.amd.js` .

`/^[\.\/~].*[^.]*\.(js|css)$/` works for me.
