### PR TITLE
Don't use connection keep alive for HTTP requests (Fixes #437)

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -485,6 +485,8 @@ Package.prototype.download = function () {
     src  = url.parse(this.assetUrl);
   }
 
+  src.agent = false;
+
   tmp.dir({
     prefix: 'bower-' + this.name + '-',
     mode: parseInt('0777', 8) & (~process.umask()),


### PR DESCRIPTION
When we process a redirect the first connection is held open until it times out. This turns off Connection: keep-alive so it doesn't happen any more.

It would be nice to understand exactly why this only causes a problem when we do a redirect, but it does fix the symptoms.
