### PR TITLE
Add --quiet and --silent command line options

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -28,7 +28,11 @@ if (reqVer && !semver.satisfies(nodeVer, reqVer)) {
   throw new Error('Required: node ' + reqVer);
 }
 
-shorthand = { 'v': ['--version'] };
+shorthand = {
+  'v': ['--version'],
+  'q': ['--quiet'],
+  's': ['--silent']
+};
 options   = { version: Boolean };
 options   = nopt(options, shorthand, process.argv);
 
@@ -41,6 +45,9 @@ command = bower.abbreviations[command];
 
 if (command) bower.command = command;
 
+if (options.silent) {
+  options.quiet = true;
+}
 
 // Temporarory fix for #22 #320 #187
 var errStatusHandler = function () {
@@ -51,16 +58,20 @@ process.on('exit', errStatusHandler);
 
 bower.commands[bower.command || 'help'].line(input)
   .on('data', function (data) {
-    if (data) process.stdout.write(data);
+    if (data && !options.quiet) process.stdout.write(data);
   })
   .on('end', function (data) {
-    if (data) process.stdout.write(data);
+    if (data && !options.quiet) process.stdout.write(data);
   })
   .on('warn', function (warning)  {
-    process.stderr.write(template('warn', { message: warning }, true));
+    if (!options.silent) {
+      process.stderr.write(template('warn', { message: warning }, true));
+    }
   })
   .on('error', function (err)  {
     if (options.verbose) throw err;
-    process.stdout.write(template('error', { message: err.message }, true));
+    if (!options.silent) {
+      process.stdout.write(template('error', { message: err.message }, true));
+    }
     errors.push(err);
   });

--- a/templates/help.mustache
+++ b/templates/help.mustache
@@ -22,5 +22,7 @@ Commands:
 Options:
 
     {{#yellow}}--no-color{{/yellow}} - Do not print colors (available in all commands)
+    {{#yellow}}--quiet{{/yellow}}    - Suppress all output except for warnings and errors (available in all commands)
+    {{#yellow}}--silent{{/yellow}}   - Suppress all output (available in all commands)
 
 See 'bower help <command>' for more information on a specific command.


### PR DESCRIPTION
Usage example:

```
bower install --quiet
bower install --silent
```

Adding `--quiet` will suppress all output except for warnings and errors.
Adding `--silent` will suppress all output.

These options behave the same as in npm. This pull request closes issue #343.
