### PR TITLE
Update link to Bower Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ package manifest, the following data can be referenced from within the
 * `package`: `flight`
 
 **N.B.** To run your own Bower Endpoint for custom packages that are behind a
-firewall, you can use a simple implementation of the [Bower
-Server](https://github.com/bower/bower-server).
+firewall, you can use a simple implementation of the [Bower Registry](https://github.com/bower/registry).
 
 
 ## Defining a package


### PR DESCRIPTION
The link to Bower Server was stale. Inspecting the various [repositories](https://github.com/bower) available under bower gave a likely replacement candidate, i.e. [registry](https://github.com/bower/registry).

Inspecting the [application.rb](https://github.com/bower/registry/blob/master/application.rb#L2) reveals the former name in the comments, confirming my assumptions about the correct link destination.
