### PR TITLE
Emit empty set when listing on for non-bower dir

### DIFF
--- a/lib/core/manager.js
+++ b/lib/core/manager.js
@@ -350,6 +350,7 @@ Manager.prototype.getDependencyList = function () {
 
   // Do not proceed if no values
   if (!values.length) {
+    this.emit('list', packages);
     return packages;
   }
 

--- a/test/list.js
+++ b/test/list.js
@@ -87,6 +87,25 @@ describe('list', function () {
       .resolve();
   });
 
+  it('Should list empty set for non-bower project', function (next) {
+    // install project. Using assets as arbitrary "non-bower" folder
+    var manager = new Manager([]);
+    manager.cwd = __dirname + '/assets';
+
+    manager
+      .on('error', function (err) {
+        throw err;
+      })
+      .on('resolve', function () {
+        list({ paths: true }).on('data', function (data) {
+          assert.deepEqual(normalize(data), {});
+
+          next();
+        });
+      })
+      .resolve();
+  });
+
   it('Should list nested map', function (next) {
     // install project
     var manager = new Manager([]);


### PR DESCRIPTION
Ensures that a callback is always made from the list command even if in
a non-bower folder.
