### PR TITLE
Typo in bower completion script.

### DIFF
--- a/templates/completion.mustache
+++ b/templates/completion.mustache
@@ -7,7 +7,7 @@
 ###-begin-bower-completion-###
 #
 # Installation: bower completion >> ~/.bashrc  (or ~/.zshrc)
-# Or, maybe: bower completion > /usr/local/etc/bash_completion.d/npm
+# Or, maybe: bower completion > /usr/local/etc/bash_completion.d/bower
 #
 
 COMP_WORDBREAKS=${COMP_WORDBREAKS/=/}


### PR DESCRIPTION
A slight typo in the bower completion script could cause some users to accidentally override their npm bash completion script.
