### PR TITLE
Added exact-match flag to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ bower search [<name>]
 
 Using just `bower search` will list all packages in the registry.
 
+If you know the exact name of your package use the '--exact-match' flag. (this is case insensitive)
+
+```
+bower search [<name>] --exact-match
+```
+
 ### Using packages
 
 The easiest approach is to use Bower statically, just reference the package's

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -14,10 +14,10 @@ var source   = require('../core/source');
 var install  = require('./install');
 var help     = require('./help');
 
-var optionTypes = { help: Boolean };
-var shorthand   = { 'h': ['--help'] };
+var optionTypes = { help: Boolean, exactMatch: Boolean };
+var shorthand   = { 'h': ['--help'], 'e':['--exact-match'] };
 
-module.exports = function (name) {
+module.exports = function (name, options) {
   var emitter = new Emitter;
 
   var callback = function (err, results) {
@@ -41,7 +41,7 @@ module.exports = function (name) {
   };
 
   if (name) {
-    source.search(name, callback);
+    source.search(name, callback, null, options['exact-match']);
   } else {
     source.all(callback);
   }
@@ -54,7 +54,7 @@ module.exports.line = function (argv) {
   var names    = options.argv.remain.slice(1);
 
   if (options.help) return help('search');
-  return module.exports(names[0]);
+  return module.exports(names[0],options);
 };
 
 module.exports.completion = install.completion;

--- a/lib/core/source.js
+++ b/lib/core/source.js
@@ -71,7 +71,7 @@ exports.register = function (name, url, callback) {
   });
 };
 
-exports.search = function (name, callback, targetEndpoints) {
+exports.search = function (name, callback, targetEndpoints, exactMatch) {
   if (!targetEndpoints) {
     targetEndpoints = endpoints;
   }
@@ -89,6 +89,9 @@ exports.search = function (name, callback, targetEndpoints) {
         var array = body && JSON.parse(body);
         for (var x = 0; x < array.length; x += 1) {
           var pkgName = array[x].name;
+          if (exactMatch && (name.toLowerCase() != pkgName.toLowerCase())) {
+            continue;
+          }
           if (!map[pkgName]) {
             map[pkgName] = pkgName;
             results.push({ name: pkgName, url: array[x].url, endpoint: array[x].endpoint });

--- a/templates/help-search.mustache
+++ b/templates/help-search.mustache
@@ -6,7 +6,8 @@ Usage:
 
 Options:
 
-    {{#yellow}}--no-color{{/yellow}} - Do not print colors
+    {{#yellow}}--exact-match{{/yellow}} - Name exact match (case insensitive)
+    {{#yellow}}--no-color{{/yellow}}    - Do not print colors
 
 Description:
 

--- a/test/search.js
+++ b/test/search.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var search = require('../lib/commands/search');
 var nock   = require('nock');
+var opts   = {};
 
 describe('search', function () {
 
@@ -17,7 +18,7 @@ describe('search', function () {
         .get('/packages/search/asdf')
         .reply(200, {});
 
-    search('asdf')
+    search('asdf',opts)
       .on('end', function () {
         next();
       });
@@ -28,7 +29,7 @@ describe('search', function () {
         .get('/packages/search/asdf')
         .reply(200, {});
 
-    search('asdf').on('packages', function (packages) {
+    search('asdf',opts).on('packages', function (packages) {
       assert.deepEqual([], packages);
       next();
     });
@@ -46,8 +47,27 @@ describe('search', function () {
         .get('/packages/search/fawagahds')
         .reply(200, expected);
 
-    search('fawagahds').on('packages', function (packages) {
+    search('fawagahds',opts).on('packages', function (packages) {
       assert.deepEqual(packages, expected);
+      next();
+    });
+  });
+
+  it('Should only match exact name when exactMatch is on', function (next) {
+    opts['exact-match'] = true;
+    var nockResponse = [
+      { name: 'fawagahds-mobile',
+        url: 'git://github.com/strongbad/fawagahds-mobile.js',
+        endpoint: undefined
+      }
+    ];
+
+    nock('https://bower.herokuapp.com')
+        .get('/packages/search/fawagahds')
+        .reply(200, nockResponse);
+
+    search('fawagahds',opts).on('packages', function (packages) {
+      assert.deepEqual([], packages);
       next();
     });
   });


### PR DESCRIPTION
Some libraries/modules have quite a bit of extensions (e.g. jquery) and searching for 'jquery' yields obtrusive results. Using the --exact-match flag will ignore case but only return libraries where it's name matches the name specified.
