### PR TITLE
Make bower do the same with '*' using semver 2 as it used to

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -76,7 +76,7 @@ var Package = function (name, endpoint, manager) {
       this.gitUrl = (RegExp.$1 || RegExp.$2) + '://' + RegExp.$3;
       this.tag    = RegExp.$4;
 
-    } else if (semver.validRange(endpoint)) {
+    } else if (semver.validRange(endpoint) && endpoint.trim() !== '*' ) {
       this.tag = endpoint;
       this.explicitName = false;
 
@@ -770,7 +770,11 @@ Package.prototype.checkout = function () {
     // If tag is specified, try to satisfy it
     if (this.tag) {
       versions = versions.filter(function (version) {
-        return semver.satisfies(version, this.tag);
+        try {
+          return semver.satisfies(version, this.tag);
+        } catch (e) {
+          return false;
+        }
       }.bind(this));
 
       if (!versions.length) {


### PR DESCRIPTION
In `semver@1.1.4`:

``` javascript
semver.validRange('*');
> false
```

`semver@2.0.7`:

``` javascript
semver.validRange('*');
> true
```

There is a very particular edge case where this causes us problems, to do with repos that have no tags AND no `bower.json` AND the dependency version is specified as `*`. Luckily that particular problem can be worked around in one line.

There is also a change in later versions of semver so that `semver.satisfies(foo bar)` will throw an exception if `bar` is not a valid semver version rather than just returning false as I think it used to. I've put a try/catch around one place where this could happen.
