### PR TITLE
remove useless -q option for commit validation to lower git requirements

### DIFF
--- a/lib/core/package.js
+++ b/lib/core/package.js
@@ -800,7 +800,7 @@ Package.prototype.checkout = function () {
 
 Package.prototype.validCommit = function (hash, callback) {
   var emitter = new events.EventEmitter();
-  var cp = git(['branch', '-q', '--contains', hash], { cwd: this.gitPath }, emitter);
+  var cp = git(['branch', '--contains', hash], { cwd: this.gitPath }, emitter);
   cp.on('close', function (code) {
     if (code) callback(false);
     callback(true);


### PR DESCRIPTION
As a follow up of #275. This PR fixes misleading error shown when commit is specified instead of version on earlier versions of git (specifically 1.7.10.2 bundled in OSX). I know that bower-canary has already fixed this issue but I think current head should have this fix as well.
