### PR TITLE
Does bower/rewrite intentionally not support "git@example.com" style repo URLs?

### DIFF
--- a/lib/util/endpointParser.js
+++ b/lib/util/endpointParser.js
@@ -41,8 +41,8 @@ function json2decomposed(key, value) {
     // If # was found, the source was specified
     if (split.length > 1) {
         endpoint += split[0] + '#' + split[1];
-    // If value has a /, it's probably a source
-    } else if (value.indexOf('/') !== -1) {
+    // If value has a / or @, it's probably a source
+    } else if (value.indexOf('/') !== -1 || value.indexOf('@') !== -1) {
         endpoint += value + '#*';
     // Otherwise use the key as the source
     } else {


### PR DESCRIPTION
I ran into an issue today where I could not use a `git@example.com` style URLs in my `bower.json`.
The readme indicates that `git://example.com` URLs are supported, but not explicitly `git@example.com` URLs.
I am aware that it is better to use `git://` for read only repos, but the current implementation of my corporate git repo only supports `git@`.
Such syntax works fine in bower/master.

I cooked up a trivial PR to demonstrate one possible implementation.

Thank you for your help and for such a useful tool! Cheers :beers:!
