### PR TITLE
fix issue#658 list not working with linked packages

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -363,7 +363,7 @@ Project.prototype.getTree = function () {
         // Find extraneous
         mout.object.forOwn(flattened, function (pkg) {
             if (pkg.extraneous) {
-                extraneous.push(this._manager.toData(pkg, ['linked']));
+                extraneous.push(this._manager.toData(pkg, ['missing', 'linked']));
             }
         }, this);
 
@@ -448,6 +448,11 @@ Project.prototype._analyse = function () {
         if (!this._options.production) {
             this._restoreNode(root, flattened, 'devDependencies');
         }
+
+        // Restore links
+        mout.object.forOwn(links, function (decEndpoint) {
+            this._restoreNode(decEndpoint, flattened, 'dependencies');
+        }, this);
 
         // Parse extraneous
         mout.object.forOwn(flattened, function (decEndpoint) {
@@ -602,18 +607,37 @@ Project.prototype._readLinks = function () {
             return Q.nfcall(fs.lstat, dir)
             .then(function (stat) {
                 if (stat.isSymbolicLink()) {
-                    decEndpoints[filename] = {
-                        name: filename,
-                        source: dir,
-                        target: '*',
-                        canonicalDir: dir,
-                        pkgMeta: {
-                            name: filename
-                        },
-                        linked: true
-                    };
+                    return Q.nfcall(bowerJson.find, dir)
+                    .then(function (jsonFile) {
+                        return Q.nfcall(bowerJson.read, jsonFile)
+                        .then(function (pkgMeta) {
+                            var name = path.basename(filename);
+
+                            decEndpoints[name] = {
+                                name: name,
+                                source: dir,
+                                target: '*',
+                                canonicalDir: dir,
+                                pkgMeta: pkgMeta,
+                                linked: true
+                            };
+                        })
+                        .fail(function (err) {
+                            throw createError('Failed to read ' + filename, err.code, {
+                                details: err.message,
+                                data: {
+                                    filename: filename
+                                }
+                            });
+                        });
+                    }, function () {
+                        // No json file was found, assume one
+                        return Q.nfcall(bowerJson.parse, {
+                            name: path.basename(dir)
+                        });
+                    });
                 }
-            });
+            }, function () {});
         });
 
         // Wait until all links have been read


### PR DESCRIPTION
This is attempting to fix the issue I noticed whereby if you link a repository (rather than install it), `bower list` doesn't show the `main` property.

I took most of the changes from the code from the _readInstalled() method.

Submitted for comment - working on a test.
