### PR TITLE
Adding syntax highlighting to bower info

### DIFF
--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -1,5 +1,6 @@
 require('colors');
 var cardinal = require('cardinal');
+var cardinalColors = require('cardinal/colors');
 var path = require('path');
 var mout = require('mout');
 var archy = require('archy');
@@ -163,6 +164,7 @@ StandardRenderer.prototype._search = function (results) {
 
 StandardRenderer.prototype._info = function (data) {
     var str;
+    var highlightedJson;
 
     // If the response is the whole package info
     // render the appropriate template
@@ -170,14 +172,17 @@ StandardRenderer.prototype._info = function (data) {
         str = template.render('std/info.std', data);
     } else {
 
-        var highlightedJsonWithPrefix = cardinal.highlight('var x = ' + stringifyObject(data, { indent: '  ' }), {
+        highlightedJson = cardinal.highlight(stringifyObject(data, { indent: '  ' }), {
             theme: {
                 String: {
-                    _default: require('cardinal/colors').green
+                    _default: cardinalColors.cyan
+                },
+                Identifier: {
+                    _default: cardinalColors.green
                 }
-            }
+            },
+            json: true
         });
-        var highlightedJson = highlightedJsonWithPrefix.substring(highlightedJsonWithPrefix.indexOf('{'));
 
         str = '\n' + highlightedJson + '\n';
     }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bower-json": "~0.2.0",
     "bower-logger": "~0.1.0",
     "bower-registry-client": "~0.1.1",
+    "cardinal": "~0.4.0",
     "chmodr": "~0.1.0",
     "colors": "~0.6.0-1",
     "fstream": "~0.1.22",
@@ -53,8 +54,7 @@
     "tmp": "~0.0.20",
     "unzip": "~0.1.7",
     "update-notifier": "~0.1.3",
-    "which": "~1.0.5",
-    "cardinal": "~0.3.2"
+    "which": "~1.0.5"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",


### PR DESCRIPTION
Implements #571.

I'm not sure that this approach is the best, but it works. What do you think?

![image](https://f.cloud.github.com/assets/829827/879016/f9656a0c-f91f-11e2-9105-ae12a601d975.png)
