### PR TITLE
Added private field support Fixes #162

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ The `bower.json` defines several options:
   Bower to ignore when installing your package.
 * `dependencies` [hash]: Packages your package depends upon in production.
 * `devDependencies` [hash]: Development dependencies.
+* `private` [boolean]: Set to true if you want to keep the package private and 
+  do not want to register the package in future.
 
 ```json
 {

--- a/lib/commands/register.js
+++ b/lib/commands/register.js
@@ -43,7 +43,11 @@ function register(name, url, config) {
         // everything is ok before registering
         repository = new PackageRepository(config, logger);
         repository.fetch({ name: name, source: url, target: '*' })
-        .then(function () {
+        .spread(function (canonicalDir, pkgMeta) {
+            if (pkgMeta.private) {
+                throw createError('The package you are trying to register is marked as private', 'EPRIV');
+            }
+
             // If non interactive or user forced, bypass confirmation
             if (!config.interactive || force) {
                 return true;


### PR DESCRIPTION
A package can now be made private using `"private": true` property in bower.json.
