### PR TITLE
fixing syntax error in help-info.json

### DIFF
--- a/templates/json/help-info.json
+++ b/templates/json/help-info.json
@@ -3,7 +3,7 @@
     "description": "Displays overall information of a package or of a particular version.",
     "usage": [
         "info <package> [<options>]",
-        "info <package> [<property>] [<options>]"
+        "info <package> [<property>] [<options>]",
         "info <package>#<version> [<property>] [<options>]"
     ],
     "options": [


### PR DESCRIPTION
running "bower info" results in an error complaining of an unexpected string, see below:

```
bower error         /usr/local/share/npm/lib/node_modules/bower/templates/json/help-info.json: Unexpected string

Stack trace:
SyntaxError: /usr/local/share/npm/lib/node_modules/bower/templates/json/help-info.json: Unexpected string
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:482:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /usr/local/share/npm/lib/node_modules/bower/lib/commands/help.js:25:20
    at Object.cb [as oncomplete] (fs.js:168:19)

Console trace:
Trace
    at StandardRenderer.error (/usr/local/share/npm/lib/node_modules/bower/lib/renderers/StandardRenderer.js:69:17)
    at Logger.updateNotifier.packageName (/usr/local/share/npm/lib/node_modules/bower/bin/bower:113:18)
    at Logger.EventEmitter.emit (events.js:95:17)
    at Logger.emit (/usr/local/share/npm/lib/node_modules/bower/node_modules/bower-logger/lib/Logger.js:29:39)
    at /usr/local/share/npm/lib/node_modules/bower/lib/commands/help.js:27:27
    at Object.cb [as oncomplete] (fs.js:168:19)

System info:
Bower version: 1.0.3
Node version: 0.10.15
OS: Darwin 12.4.0 x64
```
