### PR TITLE
add flag to log for force latest

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -667,7 +667,7 @@ Manager.prototype._electSuitable = function (name, semvers, nonSemvers) {
             name: name,
             picks: dataPicks,
             suitable: dataPicks[suitable],
-            forceLatest: true
+            forced: true
         });
         return Q.resolve(picks[suitable]);
     }


### PR DESCRIPTION
Fixes #715

This adds a flag to the `conflict` log `data` that indicates that the conflict was solved via `forceLatest`.

I confess, I didn't expect it to be so easy to add, mostly because I didn't realize this log type was already coming through.  I was so focused on `action` `install`.
