### PR TITLE
Keep original environment variables intact in asset creation script

### DIFF
--- a/test/packages.js
+++ b/test/packages.js
@@ -25,6 +25,9 @@ var env = {
     'GIT_COMMITTER_EMAIL': 'amdfcruz@gmail.com'
 };
 
+// Preserve the original environment
+mout.object.mixIn(env, process.env);
+
 function ensurePackage(dir) {
     var promise;
 


### PR DESCRIPTION
By setting the ENV to a static set of values my PATH was being ignored so `git` commands were failing. This mixes in the current environment.
