### PR TITLE
Reject the promise for a command if an error event is fired

### DIFF
--- a/lib/util/cmd.js
+++ b/lib/util/cmd.js
@@ -68,6 +68,11 @@ function cmd(command, args, options) {
         stderr += data;
     });
 
+    // If there is an error spawning the command, reject the promise
+    process.on('error', function (error) {
+        return deferred.reject(error)
+    });
+
     // Listen to the close event instead of exit
     // They are similar but close ensures that streams are flushed
     process.on('close', function (code) {


### PR DESCRIPTION
If the eventEmitter for the spawn command emits an error we should reject the promise so it can be handled gracefully rather than just dying with unhelpful messages like

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:980:11)
    at Process.ChildProcess._handle.onexit (child_process.js:771:34)
```
