### PR TITLE
Fixed JSHint errors so that it can be turned on in Travis

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,7 +26,7 @@
     "plusplus": false,
     "regexp": false,
     "undef": true,
-    "unused": true,
+    "unused": "vars",
     "quotmark": "single",
     "strict": false,
     "trailing": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function (grunt) {
             options: {
                 jshintrc: '.jshintrc'
             },
-            files: ['Gruntfile.js', 'bin/*', 'lib/**/*.js', 'test/**/*.js', '!test/assets/**/*']
+            files: ['Gruntfile.js', 'bin/*', 'lib/**/*.js', 'test/**/*.js', '!test/assets/**/*', '!test/reports/**/*']
         },
         simplemocha: {
             options: {
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-exec');
 
     grunt.registerTask('assets', ['exec:assets-force']);
-    grunt.registerTask('test', ['exec:assets', 'simplemocha:full']);
+    grunt.registerTask('test', ['jshint', 'exec:assets', 'simplemocha:full']);
     grunt.registerTask('cover', 'exec:cover');
-    grunt.registerTask('default', ['jshint', 'test']);
+    grunt.registerTask('default', 'test');
 };

--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -77,7 +77,7 @@ GitHubResolver.prototype._checkout = function () {
 
         // Progress
         msg = 'received ' + (state.received / 1024 / 1024).toFixed(1) + 'MB ';
-        msg += 'of ' + (state.total / 1024 / 1024).toFixed(1) + 'MB downloaded, ',
+        msg += 'of ' + (state.total / 1024 / 1024).toFixed(1) + 'MB downloaded, ';
         msg += state.percent + '%';
         that._logger.info('progress', msg);
     })

--- a/lib/core/resolvers/UrlResolver.js
+++ b/lib/core/resolvers/UrlResolver.js
@@ -139,7 +139,7 @@ UrlResolver.prototype._download = function () {
 
         // Progress
         msg = 'received ' + (state.received / 1024 / 1024).toFixed(1) + 'MB ';
-        msg += 'of ' + (state.total / 1024 / 1024).toFixed(1) + 'MB downloaded, ',
+        msg += 'of ' + (state.total / 1024 / 1024).toFixed(1) + 'MB downloaded, ';
         msg += state.percent + '%';
         that._logger.info('progress', msg);
     })


### PR DESCRIPTION
By changing the `.jshintrc` setting for `unused` to be `"vars"`, we can ignore the case where we have an unused parameter. This means we can have linting as part of our tests without having to remove the parameters from unimplemented functions.

Then fixed the few genuine errors and made it so that Travis will do the linting.
