### PR TITLE
allowing cache.clean to be called with no args

### DIFF
--- a/lib/commands/cache/clean.js
+++ b/lib/commands/cache/clean.js
@@ -15,8 +15,8 @@ function clean(packages, options, config) {
     options = options || {};
     config = mout.object.deepFillIn(config || {}, defaultConfig);
 
-    // If packages is an empty array, null them
-    if (packages && !packages.length) {
+    // If packages wasn't provided or is an empty array, null them
+    if (!packages || !packages.length) {
         packages = names = null;
     // Otherwise parse them
     } else {


### PR DESCRIPTION
Currently if you do this

``` javascript
bower.commands.cache.clean()
```

the code errors out:

```
TypeError: Cannot call method 'map' of undefined
  at Object.clean (pathTo/bower/lib/commands/cache/clean.js:23:29)
```

which means you have to do this:

``` javascript
bower.commands.cache.clean([])
```

which is a bit odd.

This PR allows `clean` to be called with no args.
