### PR TITLE
Fix install save shorthand

### DIFF
--- a/templates/json/help-install.json
+++ b/templates/json/help-install.json
@@ -22,7 +22,7 @@
             "description": "Do not install project devDependencies"
         },
         {
-            "shorthand":   "-s",
+            "shorthand":   "-S",
             "flag":        "--save",
             "description": "Save installed packages into the project's bower.json dependencies"
         },


### PR DESCRIPTION
The bower install help json says save with '-s', but install.js looks for a captial 'S'
