### PR TITLE
Fix to set generic userAgent if none configured if using proxy

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,6 +6,12 @@ var cli = require('./util/cli');
 // and conflicts with --json
 delete config.json;
 
+// If no userAgent is configured, use a generic one [in this case, curl] when using a proxy, 
+// to avoid potential filtering on many corporate proxies with blank or unknown agents
+if (config.proxy || config.httpsProxy) {
+	config.userAgent = 'curl/7.21.4 (universal-apple-darwin11.0) libcurl/7.21.4 OpenSSL/0.9.8r zlib/1.2.5';
+}
+
 // Merge common CLI options into the config
 mout.object.mixIn(config, cli.readOptions({
     force: { type: Boolean, shorthand: 'f' },


### PR DESCRIPTION
As per discussion with @satazor in previous issue [https://github.com/bower/bower/issues/698#issuecomment-22215528], made a fix to change the userAgent config from a generic node.js one (ex. `'node/v0.10.13 darwin x64'`) to a generic entry that isn't likely to be filtered by aggressive corporate proxy/firewall setups. In some cases, corporate firewalls will automatically reject non-tunneled http traffic that occurs with blank or unfamiliar `'User-Agent'` strings in the header. This is a tested solution to help those trapped behind proxies that are unfriendly to node `'User-Agent'` strings. 

In this case, I used `curl`, since it minimally identifies the traffic as a non-browser and is well-known and innocuous.
