### PR TITLE
Improve GitHub detection in resolverFactory.js

### DIFF
--- a/lib/core/resolverFactory.js
+++ b/lib/core/resolverFactory.js
@@ -36,7 +36,7 @@ function getConstructor(source, config, registryClient) {
         return Q.fcall(function () {
 
             // If it's a GitHub repository, return the specialized resolver
-            if (mout.string.startsWith(source, 'git://github.com')) {
+            if (/(@|:\/\/)github.com[:\/]/i.test(source)) {
                 return [resolvers.GitHub, source];
             }
 


### PR DESCRIPTION
As per @satazor's issue [https://github.com/bower/bower/issues/737] improved detection of GitHub [`git://github.com`] URLs by <del>using `mout` to capture the string rather than a regex test. `mout` is used in this capacity elsewhere is codebase, so continuing pattern.</del> making the regex detect both sides of `github.com` reliably.
