### PR TITLE
Replace `colors` with `chalk`

### DIFF
--- a/lib/commands/register.js
+++ b/lib/commands/register.js
@@ -1,6 +1,7 @@
 var mout = require('mout');
 var Q = require('q');
 var promptly = require('promptly');
+var chalk = require('chalk');
 var PackageRepository = require('../core/PackageRepository');
 var Logger = require('bower-logger');
 var cli = require('../util/cli');
@@ -55,7 +56,7 @@ function register(name, url, config) {
 
             // Confirm if the user really wants to register
             return Q.nfcall(promptly.confirm, 'Registering a package will make it visible and installable via the registry (' +
-                    config.registry.register.cyan.underline + '), continue? (y/n)');
+                    chalk.cyan.underline(config.registry.register) + '), continue? (y/n)');
         })
         .then(function (result) {
             // If user response was negative, abort

--- a/lib/renderers/JsonRenderer.js
+++ b/lib/renderers/JsonRenderer.js
@@ -1,3 +1,5 @@
+var chalk = require('chalk');
+
 function JsonRenderer() {
     this._nrLogs = 0;
 }
@@ -47,7 +49,7 @@ JsonRenderer.prototype._stringify = function (log) {
     // To json
     var str = JSON.stringify(log, null, '  ');
     // Remove colors in case some log has colors..
-    str = str.replace(/\x1B\[\d+m/g, '');
+    str = chalk.stripColor(str);
 
     return str;
 };

--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -1,6 +1,5 @@
-require('colors');
 var cardinal = require('cardinal');
-var colors = require('ansicolors');
+var chalk = require('chalk');
 var path = require('path');
 var mout = require('mout');
 var archy = require('archy');
@@ -16,11 +15,11 @@ function StandardRenderer(command, config) {
         sumup: 5   // Amount to sum when the label exceeds
     };
     this._colors = {
-        warn: 'yellow',
-        error: 'red',
-        conflict: 'magenta',
-        debug: 'grey',
-        'default': 'cyan'
+        warn: chalk.yellow,
+        error: chalk.red,
+        conflict: chalk.magenta,
+        debug: chalk.gray,
+        default: chalk.cyan
     };
 
     this._command = command;
@@ -54,7 +53,7 @@ StandardRenderer.prototype.error = function (err) {
 
     // Check if additional details were provided
     if (err.details) {
-        str = '\nAdditional error details:\n'.yellow + err.details.trim() + '\n';
+        str = chalk.yellow('\nAdditional error details:\n') + err.details.trim() + '\n';
         this._write(process.stderr, str);
     }
 
@@ -62,16 +61,16 @@ StandardRenderer.prototype.error = function (err) {
     // or if the error is a node error
     if (this._config.verbose || !err.code || err.errno) {
         /*jshint camelcase:false*/
-        str = '\nStack trace:\n'.yellow;
+        str = chalk.yellow('\nStack trace:\n');
         str += (err.fstream_stack ? err.fstream_stack.join('\n') : err.stack || 'N/A') + '\n';
-        str += '\nConsole trace:\n'.yellow;
+        str += chalk.yellow('\nConsole trace:\n');
         /*jshint camelcase:true*/
 
         this._write(process.stderr, str);
         console.trace();
 
         // Print bower version, node version and system info.
-        this._write(process.stderr, '\nSystem info:\n'.yellow);
+        this._write(process.stderr, chalk.yellow('\nSystem info:\n'));
         this._write(process.stderr, 'Bower version: ' + pkg.version + '\n');
         this._write(process.stderr, 'Node version: ' + process.versions.node + '\n');
         this._write(process.stderr, 'OS: ' + os.type() + ' ' + os.release() + ' ' + os.arch() + '\n');
@@ -174,10 +173,10 @@ StandardRenderer.prototype._info = function (data) {
         highlightedJson = cardinal.highlight(stringifyObject(data, { indent: '  ' }), {
             theme: {
                 String: {
-                    _default: colors.cyan
+                    _default: chalk.styles.cyan
                 },
                 Identifier: {
-                    _default: colors.green
+                    _default: chalk.styles.green
                 }
             },
             json: true
@@ -331,7 +330,7 @@ StandardRenderer.prototype._prefix = function (log) {
     var length;
     var nrSpaces;
     var id = this.constructor._idMappings[log.id] || log.id;
-    var idColor = this._colors[log.level] || this._colors['default'];
+    var idColor = this._colors[log.level] || this._colors.default;
 
     if (this._compact) {
         // If there's not enough space for the id, adjust it
@@ -340,7 +339,7 @@ StandardRenderer.prototype._prefix = function (log) {
             this._sizes.id = id.length += this._sizes.sumup;
         }
 
-        return mout.string.rpad(id, this._sizes.id)[idColor];
+        return idColor(mout.string.rpad(id, this._sizes.id));
     }
 
     // Construct the label
@@ -355,12 +354,12 @@ StandardRenderer.prototype._prefix = function (log) {
         nrSpaces = this._sizes.id + this._sizes.label - length;
     }
 
-    return label.green + mout.string.repeat(' ', nrSpaces) + id[idColor];
+    return chalk.green(label) + mout.string.repeat(' ', nrSpaces) + idColor(id);
 };
 
 StandardRenderer.prototype._write = function (stream, str) {
     if (!this._config.color) {
-        str = str.replace(/\x1B\[\d+m/g, '');
+        str = chalk.stripColor(str);
     }
 
     stream.write(str);
@@ -378,18 +377,18 @@ StandardRenderer.prototype._tree2archy = function (node) {
 
     // State lables
     if (node.missing) {
-        label += ' missing'.red;
+        label += chalk.red(' missing');
         return label;
     }
 
     if (node.linked) {
-        label += ' linked'.magenta;
+        label += chalk.magenta(' linked');
     }
 
     if (node.incompatible) {
-        label += ' incompatible'.yellow + ' with ' + node.endpoint.target;
+        label += chalk.yellow(' incompatible') + ' with ' + node.endpoint.target;
     } else if (node.extraneous) {
-        label += ' extraneous'.green;
+        label += chalk.green(' extraneous');
     }
 
     // New versions
@@ -408,7 +407,7 @@ StandardRenderer.prototype._tree2archy = function (node) {
         }
 
         if (update) {
-            label += ' (' + update.cyan + ')';
+            label += ' (' + chalk.cyan(update) + ')';
         }
     }
 

--- a/lib/util/template.js
+++ b/lib/util/template.js
@@ -1,4 +1,3 @@
-require('colors');
 var path = require('path');
 var fs = require('graceful-fs');
 var Handlebars = require('handlebars');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "abbrev": "~1.0.4",
-    "ansicolors": "~0.2.1",
     "archy": "0.0.2",
     "bower-config": "~0.3.0",
     "bower-endpoint-parser": "~0.2.0",
@@ -28,8 +27,8 @@
     "bower-logger": "~0.1.0",
     "bower-registry-client": "~0.1.2",
     "cardinal": "~0.4.0",
+    "chalk": "~0.2.0",
     "chmodr": "~0.1.0",
-    "colors": "~0.6.0-1",
     "fstream": "~0.1.22",
     "fstream-ignore": "~0.0.6",
     "glob": "~3.2.1",

--- a/templates/helpers/colors.js
+++ b/templates/helpers/colors.js
@@ -1,4 +1,4 @@
-require('colors');
+var chalk = require('chalk');
 
 var templateColors = [
     'yellow',
@@ -12,7 +12,7 @@ var templateColors = [
 function colors(Handlebars) {
     templateColors.forEach(function (color) {
         Handlebars.registerHelper(color, function (context) {
-            return context.fn(this)[color];
+            return chalk[color](context.fn(this));
         });
     });
 }

--- a/test/packages.js
+++ b/test/packages.js
@@ -1,4 +1,3 @@
-require('colors');
 var fs = require('graceful-fs');
 var path = require('path');
 var Q = require('q');
@@ -6,6 +5,7 @@ var semver = require('semver');
 var mout = require('mout');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
+var chalk = require('chalk');
 var cmd = require('../lib/util/cmd');
 var packages = require('./packages.json');
 var nopt = require('nopt');
@@ -173,17 +173,17 @@ mout.object.forOwn(packages, function (pkg, name) {
         .then(function (exists) {
             // Skip it if already created
             if (exists) {
-                return console.log('> '.cyan + 'Package ' + name + '#' + release + ' already created');
+                return console.log(chalk.cyan('> ') + 'Package ' + name + '#' + release + ' already created');
             }
 
             // Create it based on the metadata
             return createRelease(dir, release, files)
             .then(function () {
-                console.log('> '.green + 'Package ' + name + '#' + release + ' successfully created');
+                console.log(chalk.green('> ') + 'Package ' + name + '#' + release + ' successfully created');
             });
         })
         .fail(function (err) {
-            console.log('> '.red + 'Failed to create ' + name + '#' + release);
+            console.log(chalk.red('> ') + 'Failed to create ' + name + '#' + release);
             console.log(err.message.trim());
             if (err.details) {
                 console.log(err.details.trim());


### PR DESCRIPTION
colors.js has serious deficiencies like extending String.prototype which can cause all kinds of problems. Two modules using colors.js can conflict with each others, and it infects imported child modules. It's also better to explicit.

I created [chalk](https://github.com/sindresorhus/chalk) after experiencing the above in Yeoman.
