### PR TITLE
Fixed a grammar error

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Where `<package>` can be any one of the following:
   public or private. ‡
 * A local endpoint, i.e., a folder that's a Git repository. ‡
 * A shorthand endpoint, e.g., `someone/some-package` (defaults to GitHub). ‡
-* A URL to a file, including `zip` and `tar` files. It's contents will be
+* A URL to a file, including `zip` and `tar` files. Its contents will be
   extracted.
 
 ‡ These types of `<package>` might have versions available. You can specify a


### PR DESCRIPTION
This isn't a sophisticated edit, and it shouldn't affect any unit tests or anything. All I did was change `It's` (a contraction for "It is") to `Its` (a possessive). It's probably overkill, but I'll go ahead and cite a [source](http://public.wsu.edu/~brians/errors/its.html) :-)
