### PR TITLE
Unable to install closure-library (or any git repo at code.google.com)

### DIFF
--- a/lib/core/resolverFactory.js
+++ b/lib/core/resolverFactory.js
@@ -40,6 +40,12 @@ function getConstructor(source, config, registryClient) {
                 return [resolvers.GitHub, source];
             }
 
+            // If it's a Google Code repository, return the specialized resolver
+            if (/^https:\/\/code.google.com\//i.test(source)) {
+                return [resolvers.GitGoogle, source];
+            }
+
+
             return [resolvers.GitRemote, source];
         });
     }

--- a/lib/core/resolvers/GitGoogleResolver.js
+++ b/lib/core/resolvers/GitGoogleResolver.js
@@ -1,0 +1,76 @@
+var util = require('util');
+var mout = require('mout');
+var GitRemoteResolver = require('./GitRemoteResolver');
+var GitResolver = require('./GitResolver');
+var cmd = require('../../util/cmd');
+
+function GitGoogleResolver(decEndpoint, config, logger) {
+    GitResolver.call(this, decEndpoint, config, logger);
+}
+
+util.inherits(GitGoogleResolver, GitRemoteResolver);
+mout.object.mixIn(GitGoogleResolver, GitRemoteResolver);
+
+// -----------------
+
+GitGoogleResolver.prototype._checkout = function () {
+    var branch;
+    var promise;
+    var timer;
+    var reporter;
+    var that = this;
+    var resolution = this._resolution;
+
+    this._logger.action('checkout', resolution.tag || resolution.branch || resolution.commit, {
+        resolution: resolution,
+        to: this._tempDir
+    });
+
+    // If resolution is a commit, we need to clone the entire repo and check it out
+    // Because a commit is not a named ref, there's no better solution
+    if (resolution.type === 'commit') {
+        promise = cmd('git', ['clone', this._source, this._tempDir, '--progress'])
+        .then(cmd.bind(cmd, 'git', ['checkout', resolution.commit], { cwd: this._tempDir }));
+    // Otherwise we are checking out a named ref so we can optimize it
+    } else {
+        branch = resolution.tag || resolution.branch;
+        promise = cmd('git', ['clone',  this._source, '-b', branch, '--progress', '.'], { cwd: this._tempDir })
+        .spread(function (stdout, stderr) {
+            // Only after 1.7.10 --branch accepts tags
+            // Detect those cases and inform the user to update git otherwise it's
+            // a lot slower than newer versions
+            if (!/branch .+? not found/i.test(stderr)) {
+                return;
+            }
+
+            that._logger.warn('old-git', 'It seems you are using an old version of git, it will be slower and propitious to errors!');
+            return cmd('git', ['checkout', resolution.commit], { cwd: that._tempDir });
+        });
+    }
+
+    // Throttle the progress reporter to 1 time each sec
+    reporter = mout['function'].throttle(function (data) {
+        var lines = data.split(/[\r\n]+/);
+
+        lines.forEach(function (line) {
+            if (/\d{1,3}\%/.test(line)) {
+                // TODO: There are some strange chars that appear once in a while (\u001b[K)
+                //       Trim also those?
+                that._logger.info('progress', line.trim());
+            }
+        });
+    }, 1000);
+
+    // Start reporting progress after a few seconds
+    timer = setTimeout(function () {
+        promise.progress(reporter);
+    }, 8000);
+
+    return promise
+    // Clear timer at the end
+    .fin(function () {
+        clearTimeout(timer);
+    });
+};
+
+module.exports = GitGoogleResolver;

--- a/lib/core/resolvers/index.js
+++ b/lib/core/resolvers/index.js
@@ -2,6 +2,7 @@ module.exports = {
     GitFs: require('./GitFsResolver'),
     GitRemote: require('./GitRemoteResolver'),
     GitHub: require('./GitHubResolver'),
+    GitGoogle: require('./GitGoogleResolver'),
     Fs: require('./FsResolver'),
     Url: require('./UrlResolver')
 };


### PR DESCRIPTION
I'm trying to use Bower to grab `closure-library`.  It looks like the library is registered with `git://code.google.com/p/closure-library.git`.  This URL doesn't resolve to anything.

The [Closure Library page](https://code.google.com/p/closure-library/source/checkout) says to `git clone https://code.google.com/p/closure-library/`.

So I've tried this in `bower.json`:

``` js
  "dependencies": {
    "closure-library": "https://code.google.com/p/closure-library/"
  }
```

It looks like the resolver factory (understandably) decides this is a job for the `UrlResolver` and `index.html` is downloaded from the site.

When I try to force the `GitRemoteResolver` I'm getting a failure:

``` js
  "dependencies": {
    "closure-library": "git+https://code.google.com/p/closure-library/"
  }
```

``` shell
bower closure-library#*     not-cached https://code.google.com/p/closure-library.git#*
bower closure-library#*        resolve https://code.google.com/p/closure-library.git#*
bower closure-library#*       checkout master
bower closure-library#*        ECMDERR Failed to execute "git clone https://code.google.com/p/closure-library.git -b master --depth 1 --progress .", exit code of #128
```

This is because the `GitRemoteResolver` [trims the slash](https://github.com/bower/bower/blob/2386d46609f1e491f0a10abea5ff2b03c9c86e25/lib/core/resolvers/GitRemoteResolver.js#L10) and ensures that there is a [trailing `.git`](https://github.com/bower/bower/blob/2386d46609f1e491f0a10abea5ff2b03c9c86e25/lib/core/resolvers/GitRemoteResolver.js#L12-L15).

Should there be a config option to preserve URLs (without stripping `/` or adding `.git`)?

I imagine this is an issue with [any code.google.com project using git](https://code.google.com/p/support/wiki/GitFAQ#Can_I_access_my_repository_over_git://_or_ssh://_instead_of_http).
