### PR TITLE
, is a valid character in a path, just wrap in array if string

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -134,7 +134,7 @@ function paths(flattened) {
 
         // Normalize main
         if (typeof main === 'string') {
-            main = main.split(',');
+            main = [main];
         }
 
         // Concatenate each main entry with the canonical dir


### PR DESCRIPTION
, is not a paths separator, ref #784
