### PR TITLE
Try without shallow clone if fatal error

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -131,7 +131,7 @@ GitRemoteResolver.prototype._fastClone = function (resolution) {
         // When that happens, we mark this host and try again
         if (!GitRemoteResolver._noShallow.has(that._source) &&
             err.details &&
-            /rpc failed/i.test(err.details)
+            /(rpc failed|shallow)/i.test(err.details)
         ) {
             GitRemoteResolver._noShallow.set(that._host, true);
             return that._fastClone(resolution);


### PR DESCRIPTION
Previously, it was only considered a shallow failure if the error details matched `/rpc failed/i` (see #744, #747).  Here's what a shallow failure looks like for me:

```
$ git --version
git version 1.7.12.4

$ git clone https://code.google.com/p/closure-library -b master --progress . --depth 1
Cloning into '.'...
fatal: expected shallow/unshallow, got Error: internal server error
```
