### PR TITLE
Allow setting of cache directory by `bower_cache` env var

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,13 @@ if (config.interactive == null) {
     config.interactive = process.title === 'bower' && tty.isatty(1);
 }
 
+// If cache is set, use it as the package cache. This allows the
+// cache directory to be set by environment variable
+if (config.cache) {
+	config.storage.packages = config.cache;
+	delete config.cache;
+}
+
 // Merge common CLI options into the config
 mout.object.mixIn(config, cli.readOptions({
     force: { type: Boolean, shorthand: 'f' },


### PR DESCRIPTION
Pre 1.0 the cache directory location could be specified by the `bower_cache` environment variable.  Now that the config option for the cache directory is in `config.storage.packages` it can no longer be set by environment variable (`rc` doesn't support nested vars via environment variables).

This patch allows `bower_cache` to be used to specify the cache directory and resolves #807.

While this works, I'm wondering if it might be better to use the path specified by `bower_cache` as a base path for both `config.storage.packages` and `config.storage.registry` as they're both currently in a `.cache` directory by default.  Thoughts?
