### PR TITLE
Show linked dependencies in list command on Windows

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -631,7 +631,7 @@ Project.prototype._readLinks = function () {
                 }
 
                 // Skip links to files (see #783)
-                if (!valid.isDirectory()) {
+                if (valid.isFile()) {
                     return;
                 }
 


### PR DESCRIPTION
On Windows, linked dependencies were not showing in the 'bower list -p' command. I narrowed it down to this one liner.

Note I haven't been able to run the full test suite as I'm behind a proxy, but this had no effect on the ones I was able to run.
