### PR TITLE
Fix edge case of resolutions not working properly when resolving to branches.

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -636,8 +636,14 @@ Manager.prototype._electSuitable = function (name, semvers, nonSemvers) {
     if (resolution && !unresolvable) {
         if (semver.validRange(resolution)) {
             suitable = mout.array.findIndex(picks, function (pick) {
-                return pick.pkgMeta.version &&
-                       semver.satisfies(pick.pkgMeta.version, resolution);
+                var versionSatisfies;
+                var releaseSatisfies;
+                versionSatisfies = pick.pkgMeta.version &&
+                                   semver.satisfies(pick.pkgMeta.version, resolution);
+                releaseSatisfies = pick.pkgMeta._release &&
+                                   semver.validRange(pick.pkgMeta._release) &&
+                                   semver.satisfies(pick.pkgMeta._release, resolution);
+                return versionSatisfies || releaseSatisfies;
             });
         } else {
             suitable = mout.array.findIndex(picks, function (pick) {


### PR DESCRIPTION
There was still an edge case where a branch/tag was named with a valid semver.  The resolution would fail because the semver branch only checked the version from the bower.json.  In my particular case there is a repo with no bower.json (I have a PR in to add :-) ), but I think this behavior is consistent with other Bower behavior WRT semver in branches/tags.

Modifies bower/bower#819
Closes bower/bower#818
