### PR TITLE
Resolve endpoint using bower.json file

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -15,27 +15,27 @@ function install(endpoints, options, config) {
     project = new Project(config, logger);
 
     project.getJson()
-        .then(function (json) {
-            var jsonDeps = json.dependencies || {};
+    .then(function (json) {
+        var jsonDeps = json.dependencies || {};
 
-            // Convert endpoints to decomposed endpoints
-            endpoints = endpoints || [];
-            decEndpoints = endpoints.map(function (endpoint) {
-                // Resolve endpoint using bower.json dependencies
-                if (jsonDeps[endpoint]) {
-                    endpoint = jsonDeps[endpoint];
-                }
-                return endpointParser.decompose(endpoint);
-            });
-
-            return project.install(decEndpoints, options);
-        })
-        .then(function (installed) {
-            logger.emit('end', installed);
-        })
-        .fail(function (error) {
-            logger.emit('error', error);
+        // Convert endpoints to decomposed endpoints
+        endpoints = endpoints || [];
+        decEndpoints = endpoints.map(function (endpoint) {
+            // Resolve endpoint using bower.json dependencies
+            if (jsonDeps[endpoint]) {
+                endpoint = jsonDeps[endpoint];
+            }
+            return endpointParser.decompose(endpoint);
         });
+
+        return project.install(decEndpoints, options);
+    })
+    .then(function (installed) {
+        logger.emit('end', installed);
+    })
+    .fail(function (error) {
+        logger.emit('error', error);
+    });
 
     return logger;
 }


### PR DESCRIPTION
When I have configured dependency in `bower.json` such as

``` js
{
  "dependencies": {
     "some-lib": "org/some-lib-repo#1.0.0"
  }
}
```

I should be able to run `bower install some-lib` and bower should resolve `some-lib` to `org/some-lib-repo#1.0.0` and then install that package.
