### PR TITLE
Ensure that the whole file was downloaded.

### DIFF
--- a/lib/util/download.js
+++ b/lib/util/download.js
@@ -55,6 +55,10 @@ function download(url, file, options) {
             deferred.notify(state);
         })
         .on('end', function () {
+            // Check if the whole file was downloaded
+            // In some unstable connections the ACK/FIN packet might be sent in the
+            // middle of the download
+            // See: https://github.com/joyent/node/issues/6143
             if (contentLength && bytesDownloaded < contentLength) {
                 req.emit('error', createError('Transfer closed with ' + (contentLength - bytesDownloaded) + ' bytes remaining to read', 'EINCOMPLETE'));
             }


### PR DESCRIPTION
On unstable connections, a ACK/FIN packet might be fired in the middle of the download.
To get around this, we compare the content-length (if present) with the total number of downloaded bytes.
If they are different an error is thrown, making the whole process to fallback to `git clone`: https://github.com/bower/bower/blob/master/lib/core/resolvers/GitHubResolver.js#L109

Check https://github.com/joyent/node/issues/6143 for more information.

Fixes #792 #824 and probably #830.
