### PR TITLE
Note that commit hashes are valid versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Where `<package>` can be any one of the following:
 ‡ These types of `<package>` might have versions available. You can specify a
 [semver](http://semver.org/) compatible version to fetch a specific release, and lock the
 package to that version. You can also use ranges to specify a range of versions.
-If you are using a package that is a git endpoint, you may use tags, commit SHAs,
-or branches as a version. For example: `<package>#<sha>`. Using branches
-is not recommended, since the contents of a branch may change.
+If you are using a package that is a git endpoint, you may use any tag, commit SHA,
+or branch name as a version. For example: `<package>#<sha>`. Using branches is not
+recommended because the HEAD does not reference a fixed commit SHA.
 
 All package contents are installed in the `bower_components` directory by default.
 You should **never** directly modify the contents of this directory.


### PR DESCRIPTION
The README and website should really reflect that version numbers may be commit hashes. Unless you've been following the changelog or issues, this isn't obvious.

I'm not sure if this is the best way to communicate it, but at least it is better than nothing. :smile:
