### PR TITLE
Handle not-quite-semver tags like "1.0"

### DIFF
--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -128,18 +128,28 @@ GitResolver.prototype._findResolution = function (target) {
                 return that._resolution = { type: 'version', tag: version.tag, commit: version.commit };
             }
 
-            // Check if there's an exact branch with this name as last resort
-            return self.branches(that._source)
-            .then(function (branches) {
-                // Use hasOwn because a branch could have a name like "hasOwnProperty"
-                if (mout.object.hasOwn(branches, target)) {
-                    return that._resolution = { type: 'branch', branch: target, commit: branches[target] };
+            // Check if there's an exact tag or exact branch with this name
+            // (need to check for exact tag since "v1.0" which is a valid range but not a valid semver)
+            return self.tags(that._source)
+            .then(function (tags) {
+                // Use hasOwn because a tag could have a name like "hasOwnProperty"
+                if (mout.object.hasOwn(tags, target)) {
+                    return that._resolution = { type: 'tag', tag: target, commit: tags[target] };
                 }
 
-                throw createError('No tag found that was able to satisfy ' + target, 'ENORESTARGET', {
-                    details: !versions.length ?
-                        'No versions found in ' + that._source :
-                        'Available versions: ' + versions.map(function (version) { return version.version; }).join(', ')
+                // Check if there's an exact branch with this name as last resort
+                return self.branches(that._source)
+                .then(function (branches) {
+                    // Use hasOwn because a branch could have a name like "hasOwnProperty"
+                    if (mout.object.hasOwn(branches, target)) {
+                        return that._resolution = { type: 'branch', branch: target, commit: branches[target] };
+                    }
+
+                    throw createError('No tag found that was able to satisfy ' + target, 'ENORESTARGET', {
+                        details: !versions.length ?
+                            'No versions found in ' + that._source :
+                            'Available versions: ' + versions.map(function (version) { return version.version; }).join(', ')
+                    });
                 });
             });
         });

--- a/test/core/resolvers/gitResolver.js
+++ b/test/core/resolvers/gitResolver.js
@@ -556,6 +556,29 @@ describe('GitResolver', function () {
             .done();
         });
 
+        it('should resolve to a tag even if target is a range that does not exist', function (next) {
+            var resolver;
+
+            GitResolver.refs = function () {
+                return Q.resolve([
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/master',
+                    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb refs/tags/1.0'
+                ]);
+            };
+
+            resolver = create('foo');
+            resolver._findResolution('1.0')
+            .then(function (resolution) {
+                expect(resolution).to.eql({
+                    type: 'tag',
+                    tag: '1.0',
+                    commit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                });
+                next();
+            })
+            .done();
+        });
+
         it('should resolve to the latest pre-release version that matches a range/version', function (next) {
             var resolver;
 


### PR DESCRIPTION
Currently cannot fetch tag `1.0` because it is a valid range, but it is not a valid semver itself.

E.g.

```
bower install cowboy/jquery-throttle-debounce#v1.0

bower jquery-throttle-debounce#v1.0       not-cached git://github.com/cowboy/jquery-throttle-debounce.git#v1.0
bower jquery-throttle-debounce#v1.0          resolve git://github.com/cowboy/jquery-throttle-debounce.git#v1.0
bower jquery-throttle-debounce#v1.0     ENORESTARGET No tag found that was able to satisfy v1.0
```
