### PR TITLE
Prefer exact match when electing suitable semver

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -569,12 +569,23 @@ Manager.prototype._electSuitable = function (name, semvers, nonSemvers) {
     // If there are only semver ones, figure out the which one
     // is compatible with every requirement
     } else {
+
+        // prefer exact match
         suitable = mout.array.find(semvers, function (subject) {
-            return semvers.every(function (decEndpoint) {
+            return semver.valid(subject.target) && semvers.every(function (decEndpoint) {
                 return subject === decEndpoint ||
-                       semver.satisfies(subject.pkgMeta.version, decEndpoint.target);
+                       semver.satisfies(subject.target, decEndpoint.target);
             });
         });
+
+        if (!suitable) {
+            suitable = mout.array.find(semvers, function (subject) {
+                return semvers.every(function (decEndpoint) {
+                    return subject === decEndpoint ||
+                           semver.satisfies(subject.pkgMeta.version, decEndpoint.target);
+                });
+            });
+        }
 
         if (suitable) {
             return Q.resolve(suitable);

--- a/test/core/manager.js
+++ b/test/core/manager.js
@@ -1,0 +1,54 @@
+var expect = require('expect.js');
+var Logger = require('bower-logger');
+var Manager = require('../../lib/core/Manager');
+var defaultConfig = require('../../lib/config');
+
+describe('Manager', function () {
+    var logger;
+
+    before(function () {
+        logger = new Logger();
+    });
+
+    afterEach(function () {
+        logger.removeAllListeners();
+    });
+
+    function create() {
+        return new Manager(defaultConfig, logger);
+    }
+
+    describe('._electSuitable', function () {
+        it('should prefer exact match', function () {
+            var manager;
+            
+            var name = 'test';
+            var semvers = [
+                {
+                    name: 'test',
+                    target: '>= 1.0.0',
+                    pkgMeta: {
+                        name: 'test',
+                        version: '1.2.3'
+                    }
+                },
+                {
+                    name: 'test',
+                    target: '1.2.3+patch.1',
+                    pkgMeta: {
+                        name: 'test',
+                        version: '1.2.3+patch.1'
+                    }
+                }
+            ];
+            var nonSemvers = [];
+
+            manager = create();
+            manager._electSuitable(name, semvers, nonSemvers)
+            .then(function (suitable) {
+                expect(suitable.pkgMeta.version).to.equal('1.2.3+patch.1');
+            })
+            .done();
+        });
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -15,3 +15,4 @@ require('./core/resolvers/gitHubResolver');
 require('./core/resolverFactory');
 require('./core/resolveCache');
 require('./core/packageRepository');
+require('./core/manager');


### PR DESCRIPTION
This is only relevant for semvers with build info (e.g. `1.2.3+patch.1`) which are "semver equal" to their non-build info counterparts (e.g. `1.2.3`).

This addresses #876.
