### PR TITLE
Improve `list` message for missing packages

### DIFF
--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -414,7 +414,7 @@ StandardRenderer.prototype._tree2archy = function (node) {
 
     // State labels
     if (node.missing) {
-        label += chalk.red(' missing');
+        label += chalk.red(' not installed');
         return label;
     }
 


### PR DESCRIPTION
'missing' -> 'not installed'

Just ran into a case where `list` was saying some packages were `missing` (because of some `.gitignore` voodoo we're doing) but it was initially confusing (where is it missing from? bower's registry? locally?).

I thought 'not installed' was a bit clearer and closer to the terminology used elsewhere ('bower install').
