### PR TITLE
Add the 'moduleType' property to bower init

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -202,6 +202,12 @@ function promptUser(logger, json) {
             'type': 'input'
         },
         {
+            'name': 'moduleType',
+            'message': 'what types of modules does this package expose?',
+            'type': 'checkbox',
+            'choices': ['amd', 'es6', 'globals', 'node']
+        },
+        {
             'name': 'keywords',
             'message': 'keywords',
             'default': json.keywords ? json.keywords.toString() : null,
@@ -251,6 +257,7 @@ function promptUser(logger, json) {
         json.version = answers.version;
         json.description = answers.description;
         json.main = answers.main;
+        json.moduleType = answers.moduleType;
         json.keywords = toArray(answers.keywords);
         json.authors = toArray(answers.authors, ',');
         json.license = answers.license;

--- a/lib/renderers/JsonRenderer.js
+++ b/lib/renderers/JsonRenderer.js
@@ -88,6 +88,9 @@ JsonRenderer.prototype.prompt = function (prompts) {
         case 'password':
             funcName = prompt.type;
             break;
+        case 'checkbox':
+            funcName = 'prompt';
+            break;
         default:
             promise = promise.then(function () {
                 throw createError('Unknown prompt type', 'ENOTSUP');
@@ -105,6 +108,12 @@ JsonRenderer.prototype.prompt = function (prompts) {
                 answers[prompt.name] = answer;
             });
         });
+
+        if (prompt.type === 'checkbox') {
+            promise = promise.then(function () {
+                answers[prompt.name] = answers[prompt.name].split(',');
+            });
+        }
     });
 
     return promise.then(function () {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bower-config": "~0.5.0",
     "bower-endpoint-parser": "~0.2.0",
     "bower-json": "~0.4.0",
-    "bower-logger": "~0.2.1",
+    "bower-logger": "~0.2.2",
     "bower-registry-client": "~0.1.4",
     "cardinal": "~0.4.0",
     "chalk": "~0.2.0",


### PR DESCRIPTION
This PR is dependent on https://github.com/bower/logger/pull/2 being pulled and a new version of `bower-logger` being published because the prompt is multiple-selection.
