### PR TITLE
Fix considering extended directory using .bowerrc

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -23,8 +23,6 @@ function list(options, config) {
 
     project.getTree()
     .spread(function (tree, flattened) {
-        var baseDir = path.dirname(path.join(config.cwd, config.directory));
-
         // Relativize paths
         // Also normalize paths on windows
         project.walkTree(tree, function (node) {
@@ -33,6 +31,7 @@ function list(options, config) {
             }
 
             if (options.relative) {
+                var baseDir = path.dirname(path.join(config.cwd, node.pkgMeta.name));
                 node.canonicalDir = path.relative(baseDir, node.canonicalDir);
             }
             if (options.paths) {
@@ -48,6 +47,7 @@ function list(options, config) {
             }
 
             if (options.relative) {
+                var baseDir = path.dirname(path.join(config.cwd, node.pkgMeta.name));
                 node.canonicalDir = path.relative(baseDir, node.canonicalDir);
             }
             if (options.paths) {


### PR DESCRIPTION
Hi there, 

i try to use `bower.commans.list({paths: true})` into the `grunt-bower-task` module.
also i extended directory path using `.bowerrc`. then, this canonicalDir is not considered a extented directory.
so I fixed that. i thinks related to this isseu. https://github.com/bower/bower/issues/714

thank you.
