### PR TITLE
Added bower version command, like npm version

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -13,5 +13,6 @@ module.exports = {
     register: require('./register'),
     search: require('./search'),
     update: require('./update'),
-    uninstall: require('./uninstall')
+    uninstall: require('./uninstall'),
+    version: require('./version')
 };

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -1,0 +1,140 @@
+var mout = require('mout');
+var semver = require('semver');
+var Logger = require('bower-logger');
+var which = require('which');
+var fs = require('fs');
+var path = require('path');
+var Q = require('q');
+var execFile = require('child_process').execFile;
+var Project = require('../core/Project');
+var cli = require('../util/cli');
+var defaultConfig = require('../config');
+var createError = require('../util/createError');
+
+function version(versionArg, options, config) {
+    var project;
+    var logger = new Logger();
+
+    config = mout.object.deepFillIn(config || {}, defaultConfig);
+    project = new Project(config, logger);
+
+    bump(project, versionArg, options.message)
+    .done(function () {
+        logger.emit('end');
+    }, function (error) {
+        logger.emit('error', error);
+    });
+
+    return logger;
+}
+
+function bump(project, versionArg, message) {
+    var newVersion;
+    var doGitCommit = false;
+
+    return checkGit()
+    .then(function (hasGit) {
+        doGitCommit = hasGit;
+    })
+    .then(project.getJson.bind(project))
+    .then(function (json) {
+        newVersion = getNewVersion(json.version, versionArg);
+        json.version = newVersion;
+    })
+    .then(project.saveJson.bind(project))
+    .then(function () {
+        if (doGitCommit) {
+            return gitCommitAndTag(newVersion, message);
+        }
+    })
+    .then(function () {
+        console.log('v' + newVersion);
+    });
+}
+
+function getNewVersion(currentVersion, versionArg) {
+    var newVersion = semver.valid(versionArg);
+    if (!newVersion) {
+        newVersion = semver.inc(currentVersion, versionArg);
+    }
+    if (!newVersion) {
+        throw createError('Invalid version argument: `' + versionArg + '`. Usage: `bower version [<newversion> | major | minor | patch]`', 'EINVALIDVERSION');
+    }
+    if (currentVersion === newVersion) {
+        throw createError('Version not changed', 'EVERSIONNOTCHANGED');
+    }
+    return newVersion;
+}
+
+function checkGit() {
+    var gitDir = path.join(process.cwd(), '.git');
+    return Q.nfcall(fs.stat, gitDir)
+    .then(function (stat) {
+        if (stat.isDirectory()) {
+            return checkGitStatus();
+        }
+        return false;
+    }, function () {
+        //Ignore not found .git directory
+        return false;
+    });
+}
+
+function checkGitStatus() {
+    return Q.nfcall(which, 'git')
+    .fail(function (err) {
+        err.code = 'ENOGIT';
+        throw err;
+    })
+    .then(function () {
+        return Q.nfcall(execFile, 'git', ['status', '--porcelain'], {env: process.env});
+    })
+    .then(function (value) {
+        var stdout = value[0];
+        var lines = filterModifiedStatusLines(stdout);
+        if (lines.length) {
+            throw createError('Git working directory not clean.\n' + lines.join('\n'), 'EWORKINGDIRECTORYDIRTY');
+        }
+        return true;
+    });
+}
+
+function filterModifiedStatusLines(stdout) {
+    return stdout.trim().split('\n')
+    .filter(function (line) {
+        return line.trim() && !line.match(/^\?\? /);
+    }).map(function (line) {
+        return line.trim();
+    });
+}
+
+function gitCommitAndTag(newVersion, message) {
+    message = message || 'v' + newVersion;
+    message = message.replace(/%s/g, newVersion);
+    return Q.nfcall(execFile, 'git', ['add', 'bower.json'], {env: process.env})
+    .then(function () {
+        return Q.nfcall(execFile, 'git', ['commit', '-m', message], {env: process.env});
+    })
+    .then(function () {
+        return Q.nfcall(execFile, 'git', ['tag', newVersion, '-am', message], {env: process.env});
+    });
+}
+
+// -------------------
+
+version.line = function (argv) {
+    var options = version.options(argv);
+    return version(options.argv.remain[1], options);
+};
+
+version.options = function (argv) {
+    return cli.readOptions({
+        'message': { type: String, shorthand: 'm'}
+    }, argv);
+};
+
+version.completion = function () {
+    // TODO:
+};
+
+module.exports = version;

--- a/templates/json/help-version.json
+++ b/templates/json/help-version.json
@@ -1,0 +1,14 @@
+{
+    "command": "version",
+    "description": "Run this in a package directory to bump the version and write the new data back to the bower.json file.\n\nThe newversion argument should be a valid semver string, or a valid second argument to semver.inc (one of \"build\", \"patch\", \"minor\", or \"major\"). In the second case, the existing version will be incremented\nby 1 in the specified field.\n\nIf run in a git repo, it will also create a version commit and tag, and fail if the repo is not clean.\n\nIf supplied with --message (shorthand: -m) config option, bower will use it as a commit message when creating a version commit. If the message config contains %s then that will be replaced with the resulting\nversion number. For example:\n\n    bower version patch -m \"Upgrade to %s for reasons\"",
+    "usage": [
+        "version [<newversion> | major | minor | patch]"
+    ],
+    "options": [
+        {
+            "shorthand":   "-m",
+            "flag":        "--message",
+            "description": "Custom git commit and tag message"
+        }
+    ]
+}

--- a/templates/json/help.json
+++ b/templates/json/help.json
@@ -16,7 +16,8 @@
         "register":        "Register a package",
         "search":          "Search for a package by name",
         "update":          "Update a local package",
-        "uninstall":       "Remove a local package"
+        "uninstall":       "Remove a local package",
+        "version":         "Bump a package version"
     },
     "options": [
         {


### PR DESCRIPTION
I'm a happy user of [`npm version`](https://npmjs.org/doc/cli/npm-version.html), and I needed the same functionality in bower, so I decided to write the functionality (inspired by npm's implementation).

It works just like `npm version`:

```
version [<newversion> | major | minor | patch]
```

I didn't find any tests for the other bower commands, so I'm in doubt of how to write automated tests for this command? :whale2:

Let me know if there are any things in the code you would like me to fix.
