### PR TITLE
Added config fallback for allow-root check

### DIFF
--- a/lib/util/rootCheck.js
+++ b/lib/util/rootCheck.js
@@ -10,7 +10,7 @@ function rootCheck(options, config) {
     var errorMsg;
 
     // Allow running the command as root
-    if (options.allowRoot) {
+    if (options.allowRoot || config.allowRoot) {
         return;
     }
 


### PR DESCRIPTION
Added this fallback for the "allow-root" flag so that if it's not set by a command line option then it will check if it's set in any other config settings.
