### PR TITLE
Fixed an infinite recursion bug

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -371,6 +371,8 @@ Manager.prototype._failFast = function () {
 };
 
 Manager.prototype._parseDependencies = function (decEndpoint, pkgMeta, jsonKey) {
+    var pending = [];
+
     decEndpoint.dependencies = decEndpoint.dependencies || {};
 
     // Parse package dependencies
@@ -426,10 +428,7 @@ Manager.prototype._parseDependencies = function (decEndpoint, pkgMeta, jsonKey) 
             }, this);
 
             if (compatible) {
-                compatible.promise
-                .then(function () {
-                    this._parseDependencies(decEndpoint, pkgMeta, jsonKey);
-                }.bind(this));
+                pending.push(compatible.promise);
                 return;
             }
         }
@@ -442,6 +441,13 @@ Manager.prototype._parseDependencies = function (decEndpoint, pkgMeta, jsonKey) 
         childDecEndpoint.dependants = [decEndpoint];
         this._fetch(childDecEndpoint);
     }, this);
+
+    if (pending.length > 0) {
+        Q.all(pending)
+        .then(function () {
+            this._parseDependencies(decEndpoint, pkgMeta, jsonKey);
+        }.bind(this));
+    }
 };
 
 Manager.prototype._dissect = function () {


### PR DESCRIPTION
Well, probably not infinite, actually.

`bower install git://github.com/Polymer/designer.git#e9696a03e506efaaa070989effdf4c272d23c0a2` was taking a very long time.

When a package has a dependency that we are still fetching:

Old logic: re-parse all of the dependencies for the package when this particular dependency has been fetched. If `n` dependencies are being fetched, re-parse ALL dependencies `n` times. When the first one resolves we will end up adding a `.then` for each of the still fetching ones again. Off the top of my head I think this is O(n!).

New logic: re-parse all of the dependencies just ONCE when ALL of the in-flight dependencies have resolved.
