### PR TITLE
readme: npm install -> sudo npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /bower.json
 /component.json
 /bower_components
+
+.idea

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Bower depends on [Node](http://nodejs.org/) and [npm](http://npmjs.org/). It's
 installed globally using npm:
 
 ```
-npm install -g bower
+sudo npm install -g bower
 ```
 
 Also make sure that [git](http://git-scm.com/) is installed as some bower


### PR DESCRIPTION
Maybe it should be instructed to use `sudo npm install` instead? Without it I got this: 

> Adams-MacBook-Pro:~ adam$ npm install -g bower
> 
> npm http GET https://registry.npmjs.org/bower
> npm http 200 https://registry.npmjs.org/bower
> npm http GET https://registry.npmjs.org/bower/-/bower-1.2.8.tgz
> npm http 200 https://registry.npmjs.org/bower/-/bower-1.2.8.tgz
> npm ERR! Error: EACCES, mkdir '/usr/local/lib/node_modules/bower'
> npm ERR!  { [Error: EACCES, mkdir '/usr/local/lib/node_modules/bower']
> npm ERR!   errno: 3,
> npm ERR!   code: 'EACCES',
> npm ERR!   path: '/usr/local/lib/node_modules/bower',
> npm ERR!   fstream_type: 'Directory',
> npm ERR!   fstream_path: '/usr/local/lib/node_modules/bower',
> npm ERR!   fstream_class: 'DirWriter',
> npm ERR!   fstream_stack: 
> npm ERR!    [ '/usr/local/lib/node_modules/npm/node_modules/fstream/lib/dir-writer.js:36:23',
> npm ERR!      '/usr/local/lib/node_modules/npm/node_modules/mkdirp/index.js:37:53',
> npm ERR!      'Object.oncomplete (fs.js:107:15)' ] }
> npm ERR! 
> npm ERR! Please try running this command again as root/Administrator.
> 
> npm ERR! System Darwin 12.5.0
> npm ERR! command "node" "/usr/local/bin/npm" "install" "-g" "bower"
> npm ERR! cwd /Users/adam
> npm ERR! node -v v0.10.21
> npm ERR! npm -v 1.3.11
> npm ERR! path /usr/local/lib/node_modules/bower
> npm ERR! fstream_path /usr/local/lib/node_modules/bower
> npm ERR! fstream_type Directory
> npm ERR! fstream_class DirWriter
> npm ERR! code EACCES
> npm ERR! errno 3
> npm ERR! stack Error: EACCES, mkdir '/usr/local/lib/node_modules/bower'
> npm ERR! fstream_stack /usr/local/lib/node_modules/npm/node_modules/fstream/lib/dir-writer.js:36:23
> npm ERR! fstream_stack /usr/local/lib/node_modules/npm/node_modules/mkdirp/index.js:37:53
> npm ERR! fstream_stack Object.oncomplete (fs.js:107:15)
> npm ERR! 
> npm ERR! Additional logging details can be found in:
> npm ERR!     /Users/adam/npm-debug.log
> npm ERR! not ok code 0
