### PR TITLE
Changed to uppercase S as shorthand for save

### DIFF
--- a/templates/json/help-uninstall.json
+++ b/templates/json/help-uninstall.json
@@ -11,7 +11,7 @@
             "description": "Show this help message"
         },
         {
-            "shorthand":   "-s",
+            "shorthand":   "-S",
             "flag":        "--save",
             "description": "Save installed packages into the project's bower.json dependencies"
         },


### PR DESCRIPTION
Before the help showed lowercase s '-s' as the option to save installed packages, which doesn't work.
