### PR TITLE
Prevents overwrite of linked dependencies

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -118,20 +118,22 @@ Project.prototype.update = function (names, options) {
     // Analyse the project
     return this._analyse()
     .spread(function (json, tree, flattened) {
+        var processNode = function (node) {
+            // We don't know the real source of linked packages
+            // Instead we read its dependencies
+            if (node.linked) {
+                mout.object.values(node.dependencies).forEach(processNode);
+            } else {
+                targets.push(node);
+            }
+
+            return false;
+        };
+
         // If no names were specified, update every package
         if (!names) {
             // Mark each root dependency as targets
-            that.walkTree(tree, function (node) {
-                // We don't know the real source of linked packages
-                // Instead we read its dependencies
-                if (node.linked) {
-                    targets.push.apply(targets, mout.object.values(node.dependencies));
-                } else {
-                    targets.push(node);
-                }
-
-                return false;
-            }, true);
+            that.walkTree(tree, processNode, true);
         // Otherwise, selectively update the specified ones
         } else {
             // Error out if some of the specified names
@@ -147,15 +149,7 @@ Project.prototype.update = function (names, options) {
             // Add packages whose names are specified to be updated
             that.walkTree(tree, function (node, name) {
                 if (names.indexOf(name) !== -1) {
-                    // We don't know the real source of linked packages
-                    // Instead we read its dependencies
-                    if (node.linked) {
-                        targets.push.apply(targets, mout.object.values(node.dependencies));
-                    } else {
-                        targets.push(node);
-                    }
-
-                    return false;
+                    processNode(node);
                 }
             }, true);
 


### PR DESCRIPTION
When a linked package has a dependency that itself is linked, the link was replaced with the installed dependency package. This update causes the update command, and by extension, the link command, to not overwrite linked dependencies of a linked package.

This can be replicated by creating three bower packages and issuing the following commands:

/src/A/bower.json:

``` json
{
  "name": "A",
  "version": "0.0.0",
  "license": "MIT",
  "private": true,
  "dependencies": {
    "B": "/src/B"
  }
}
```

/src/B/bower.json:

``` json
{
  "name": "B",
  "version": "0.0.0",
  "license": "MIT",
  "private": true,
  "dependencies": {
    "C": "/src/C"
  }
}
```

/src/C/bower.json:

``` json
{
  "name": "C",
  "version": "0.0.0",
  "license": "MIT",
  "private": true
}
```

Then, create a link to C in A:

``` shell
cd /src/C
bower link
cd /src/A
bower link C
```

Finally, create a link to B in A:

``` shell
cd /src/B
bower link
cd /src/A
bower link B
```

We expect that linking B into A should not remove the link that A has on C.
