### PR TITLE
add fallback support to dumb http servers

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -133,7 +133,7 @@ GitRemoteResolver.prototype._fastClone = function (resolution) {
         // When that happens, we mark this host and try again
         if (!GitRemoteResolver._noShallow.has(that._source) &&
             err.details &&
-            /(rpc failed|shallow)/i.test(err.details)
+            /(rpc failed|shallow|--depth)/i.test(err.details)
         ) {
             GitRemoteResolver._noShallow.set(that._host, true);
             return that._fastClone(resolution);


### PR DESCRIPTION
Currently, bower does not support dumb http servers.

```
bower install http://foobar.com/foobar.git
bower foobar#*       not-cached http://foobar.com/foobar.git#*      
bower foobar#*          resolve http://foobar.com/foobar.git#*      
bower foobar#*         checkout master                                           
bower foobar#*          ECMDERR Failed to execute "git clone http://foobar.com/foobar.git -b master --progress . --depth 1", exit code of #128    
```

There is already a mechanism in place to support a fallback to not use depth, it just isn't catching this case.

The entire err.details for this case is

```
Cloning into \'.\'...\nfatal: dumb http transport does not support --depth\n
```

I tried to keep the addition as brief as possible, assuming that any err that includes the string `--depth` most likely does not support it.
