### PR TITLE
Fix race condition when writing into the cache (issued in #933)

### DIFF
--- a/lib/core/ResolveCache.js
+++ b/lib/core/ResolveCache.js
@@ -126,6 +126,16 @@ ResolveCache.prototype.store = function (canonicalDir, pkgMeta) {
         .then(function () {
             return Q.nfcall(fs.rename, canonicalDir, dir)
             .fail(function (err) {
+                // If error is ENOTEMPTY it means that we are trying to name
+                // to target which already exist. This can happens when multiple
+                // downloads were inited in parallel. We can skip this because
+                // we had already deleted an outdated cache one promise before.
+                // (issued in #933)
+                if (err.code === 'ENOTEMPTY') {
+                    // We can safely delete the fetched content.
+                    return Q.nfcall(rimraf, canonicalDir);
+                }
+
                 // If error is EXDEV it means that we are trying to rename
                 // across different drives, so we copy and remove it instead
                 if (err.code !== 'EXDEV') {


### PR DESCRIPTION
This fix avoids the random `ENOEMPTY` errors occured when parallel
downloads of the same source finished and tries to write to the same
cache target directory.

This patch does not change the internal source cache handling.
The only purpose of this patch is avoiding an error „directory already
exist“ in a promise flow in which this was already ensured.

---

Okay. So far my proposal. It does not fix the real problem (parallel downloads), but we could have a solution for #933.

Additionally, I have no clue how to provide a test case for that racing condition. I've tried it locally with the Network Link Conditioner of OS X.. but that one takes several tries.
