### PR TITLE
Fix reading versions from cache directory.

### DIFF
--- a/lib/core/ResolveCache.js
+++ b/lib/core/ResolveCache.js
@@ -76,7 +76,7 @@ ResolveCache.prototype.retrieve = function (source, target) {
         }
 
         // Resolve with canonical dir and package meta
-        canonicalDir = path.join(dir, version);
+        canonicalDir = path.join(dir, encodeURIComponent(version));
         return that._readPkgMeta(canonicalDir)
         .then(function (pkgMeta) {
             return [canonicalDir, pkgMeta];
@@ -346,6 +346,7 @@ ResolveCache.prototype._getVersions = function (sourceId) {
     .then(function (versions) {
         // Sort and cache in memory
         that._sortVersions(versions);
+        versions = versions.map(decodeURIComponent);
         that._cache.set(sourceId, versions);
         return [versions, false];
     }, function (err) {

--- a/test/core/resolveCache.js
+++ b/test/core/resolveCache.js
@@ -529,6 +529,7 @@ describe('ResolveCache', function () {
             var sourceId = md5(source);
             var sourceDir = path.join(cacheDir, sourceId);
             var json = { name: 'foo' };
+            var encoded;
 
             // Create some versions
             fs.mkdirSync(sourceDir);
@@ -538,22 +539,25 @@ describe('ResolveCache', function () {
             fs.writeFileSync(path.join(sourceDir, '0.1.0', '.bower.json'), JSON.stringify(json, null, '  '));
 
             json.version = '0.1.0+build.4';
-            fs.mkdirSync(path.join(sourceDir, '0.1.0+build.4'));
-            fs.writeFileSync(path.join(sourceDir, '0.1.0+build.4', '.bower.json'), JSON.stringify(json, null, '  '));
+            encoded = encodeURIComponent('0.1.0+build.4');
+            fs.mkdirSync(path.join(sourceDir, encoded));
+            fs.writeFileSync(path.join(sourceDir, encoded, '.bower.json'), JSON.stringify(json, null, '  '));
 
             json.version = '0.1.0+build.5';
-            fs.mkdirSync(path.join(sourceDir, '0.1.0+build.5'));
-            fs.writeFileSync(path.join(sourceDir, '0.1.0+build.5', '.bower.json'), JSON.stringify(json, null, '  '));
+            encoded = encodeURIComponent('0.1.0+build.5');
+            fs.mkdirSync(path.join(sourceDir, encoded));
+            fs.writeFileSync(path.join(sourceDir, encoded, '.bower.json'), JSON.stringify(json, null, '  '));
 
             json.version = '0.1.0+build.6';
-            fs.mkdirSync(path.join(sourceDir, '0.1.0+build.6'));
-            fs.writeFileSync(path.join(sourceDir, '0.1.0+build.6', '.bower.json'), JSON.stringify(json, null, '  '));
+            encoded = encodeURIComponent('0.1.0+build.6');
+            fs.mkdirSync(path.join(sourceDir, encoded));
+            fs.writeFileSync(path.join(sourceDir, encoded, '.bower.json'), JSON.stringify(json, null, '  '));
 
             resolveCache.retrieve(source, '0.1.0+build.5')
             .spread(function (canonicalDir, pkgMeta) {
                 expect(pkgMeta).to.be.an('object');
                 expect(pkgMeta.version).to.equal('0.1.0+build.5');
-                expect(canonicalDir).to.equal(path.join(sourceDir, '0.1.0+build.5'));
+                expect(canonicalDir).to.equal(path.join(sourceDir, encodeURIComponent('0.1.0+build.5')));
 
                 next();
             })


### PR DESCRIPTION
When we write into directory we use encodeURIComponent, but when we read, we did nothing. Now we use decodeURIComponent to read the correct version and match the correct cache directory.

Actually, all tag containing a "+" (example "v1.2.11-build.2185+sha.4f735b0") are not correctly read from cache.

Fix #1075 
