### PR TITLE
Update copyright year from 2012 to 2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,6 @@ Thanks for assistance and contributions:
 
 ## License
 
-Copyright 2012 Twitter, Inc.
+Copyright 2014 Twitter, Inc.
 
 Licensed under the MIT License


### PR DESCRIPTION
The copyright year was out of date (2012). Copyright notices must list the current year. This commit updates the listed year to 2014.
