### PR TITLE
Fix misspelled message showing in console

### DIFF
--- a/templates/std/conflict.std
+++ b/templates/std/conflict.std
@@ -1,7 +1,7 @@
 {{#yellow}}Unable to find a suitable version for {{name}}, please choose one:{{/yellow}}
 {{#condense}}
 {{#each picks}}
-    {{#magenta}}{{sum @index 1}}){{/magenta}} {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#white}}{{pkgMeta._release}}{{/white}}{{/if}}{{#if dependants}} and has {{#white}}{{dependants}}{{/white}} as dependants{{/if}}
+    {{#magenta}}{{sum @index 1}}){{/magenta}} {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#white}}{{pkgMeta._release}}{{/white}}{{/if}}{{#if dependants}} and has {{#white}}{{dependants}}{{/white}} as dependencies{{/if}}
 {{/each}}
 {{/condense}}
 {{#unless saveResolutions}}


### PR DESCRIPTION
The conflict message printed out to the console is showing the misspelled word "dependants." This fix corrects the spelling. 
