### PR TITLE
Allow circular dependencies to be installed

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -194,11 +194,13 @@ Manager.prototype.install = function () {
     }.bind(this));
 };
 
-Manager.prototype.toData = function (decEndpoint, extraKeys) {
+Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps) {
     var names;
     var extra;
 
     var data = {};
+
+    upperDeps = upperDeps || [];
     data.endpoint = mout.object.pick(decEndpoint, ['name', 'source', 'target']);
 
     if (decEndpoint.canonicalDir) {
@@ -221,7 +223,14 @@ Manager.prototype.toData = function (decEndpoint, extraKeys) {
         // by dependency names
         names = Object.keys(decEndpoint.dependencies).sort();
         names.forEach(function (name) {
-            data.dependencies[name] = this.toData(decEndpoint.dependencies[name], extraKeys);
+
+            // Prevent from infinite recursion when installing cyclic
+            // dependencies
+            if (!mout.array.contains(upperDeps, name)) {
+                data.dependencies[name] = this.toData(decEndpoint.dependencies[name],
+                    extraKeys,
+                    upperDeps.concat(decEndpoint.name));
+            }
         }, this);
     }
 


### PR DESCRIPTION
When two packages are depend on each other (directly or inderectly), `bower install` crashes with maximum call stack error. The error is caused by recursive `Manager.toData` method. 

This patch fixes it by skipping, dependencies of  the endpoint if they are equal to one of the parent endpoints.
