### PR TITLE
Run git ls-remote in a temp directory instead of project directory

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -1,3 +1,4 @@
+var osenv = require('osenv');
 var util = require('util');
 var url = require('url');
 var Q = require('q');
@@ -170,7 +171,7 @@ GitRemoteResolver.refs = function (source) {
     }
 
     // Store the promise in the refs object
-    value = cmd('git', ['ls-remote', '--tags', '--heads', source])
+    value = cmd('git', ['ls-remote', '--tags', '--heads', source], { cwd : osenv.tmpdir() })
     .spread(function (stdout) {
         var refs;
 


### PR DESCRIPTION
For now it is possible that projects `.git/config` contains git url rewrites (`insteadOf`) so they will affect `bower`.

This proposes that run of `git ls-remote` command would be run in a separate working directory (`osenv.tmpdir()`) so it is not affected by these configs.

In our case it is fixes quite rare bugs with TeamCity (with enabled `teamcity.git.use.local.mirrors=true` agent option) and projects that depend on itself (directly or indirectly) and are installed by branches refs.

/cc @SevInf @cody-
