### PR TITLE
Suppress end output if quiet option is specified

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -105,7 +105,7 @@ analytics.setup().then(function () {
 
     logger
     .on('end', function (data) {
-        if (!bower.config.silent) {
+        if (!bower.config.silent && !bower.config.quiet) {
             renderer.end(data);
         }
     })


### PR DESCRIPTION
When --quiet is used, only warnings and errors should appear in stdout. Currently, the end output of an operation is still being shown.
