### PR TITLE
Support custom components dir via cli param.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,7 @@ mout.object.mixIn(config, cli.readOptions({
     quiet: { type: Boolean, shorthand: 'q' },
     loglevel: { type: String, shorthand: 'l' },
     json: { type: Boolean, shorthand: 'j' },
+    componentsDir: { type: String, shorthand: 'c' },
     silent: { type: Boolean, shorthand: 's' }
 }));
 

--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -123,7 +123,7 @@ Manager.prototype.install = function (json) {
         return Q.resolve({});
     }
 
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = this._config.componentsDir;
     return Q.nfcall(mkdirp, componentsDir)
     .then(function () {
         return scripts.preinstall(that._config, that._logger, that._dissected, that._installed, json);
@@ -553,7 +553,7 @@ Manager.prototype._dissect = function () {
         }, this);
 
         // Filter only packages that need to be installed
-        componentsDir = path.resolve(that._config.cwd, that._config.directory);
+        componentsDir = that._config.componentsDir;
         this._dissected = mout.object.filter(suitables, function (decEndpoint, name) {
             var installedMeta = this._installed[name];
             var dst;

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -566,7 +566,7 @@ Project.prototype._readInstalled = function () {
 
     // Gather all folders that are actual packages by
     // looking for the package metadata file
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = this._config.componentsDir;
     return this._installed = Q.nfcall(glob, '*/.bower.json', {
         cwd: componentsDir,
         dot: true
@@ -607,7 +607,7 @@ Project.prototype._readLinks = function () {
     var that = this;
 
     // Read directory, looking for links
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = this._config.componentsDir;
     return Q.nfcall(fs.readdir, componentsDir)
     .then(function (filenames) {
         var promises;

--- a/templates/json/help.json
+++ b/templates/json/help.json
@@ -46,6 +46,11 @@
             "description": "Only output important information"
         },
         {
+            "shorthand":   "-c",
+            "flag":        "--componentsDir",
+            "description": "Change default components directory"
+        },
+        {
             "shorthand":   "-s",
             "flag":        "--silent",
             "description": "Do not output anything, besides errors"

--- a/test/core/scripts.js
+++ b/test/core/scripts.js
@@ -11,9 +11,11 @@ describe('scripts', function () {
     var tempDir = path.join(__dirname, '../assets/temp-scripts');
     var packageName = 'package-zip';
     var packageDir = path.join('..', packageName + '.zip');
+    var componentsDir = tempDir + '/foo';
 
     var config = {
         cwd: tempDir,
+        componentsDir: componentsDir,
         scripts: {
             preinstall: 'touch preinstall_%',
             postinstall: 'touch postinstall_%',


### PR DESCRIPTION
Partly fixes issue #1107.
You can now use: 

```
 bower install --componentsDir=/path/to/components_directory /path/to/project_directory
```
