### PR TITLE
Add YUI modules as a `moduleType` choice

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -205,7 +205,7 @@ function promptUser(logger, json) {
             'name': 'moduleType',
             'message': 'what types of modules does this package expose?',
             'type': 'checkbox',
-            'choices': ['amd', 'es6', 'globals', 'node']
+            'choices': ['amd', 'es6', 'globals', 'node', 'yui']
         },
         {
             'name': 'keywords',


### PR DESCRIPTION
This adds `"yui"` as a choice for the `moduleType` field. There is lots of code in YUI modules and we'd like to get on board with using Bower as a key piece of the infrastructure for sharing and using YUI modules.
