### PR TITLE
Fix problem with dashes and underscores in branch/tag names

### DIFF
--- a/lib/core/resolvers/SvnResolver.js
+++ b/lib/core/resolvers/SvnResolver.js
@@ -340,25 +340,11 @@ SvnResolver.tags = function (source) {
 
     value = cmd('svn', ['list', source + '/tags', '--verbose'])
     .spread(function (stout) {
-        var tags = {};
-
-        var lines = stout.toString()
-        .trim()
-        .split(/[\r\n]+/);
-
-        // For each line in the refs, match only the tags
-        lines.forEach(function (line) {
-
-            var match = line.match(/\s+([0-9]+)\s.+\s([a-z0-9.]+)\//i);
-
-            if (match && match[2] !== '.') {
-                tags[match[2]] = match[1];
-            }
-        });
+        var tags = SvnResolver.parseSubversionListOutput(stout.toString());
 
         this._cache.tags.set(source, tags);
-
         return tags;
+
     }.bind(this));
 
     // Store the promise to be reused until it resolves
@@ -379,28 +365,14 @@ SvnResolver.branches = function (source) {
 
     value = cmd('svn', ['list', source + '/branches', '--verbose'])
     .spread(function (stout) {
+        var branches = SvnResolver.parseSubversionListOutput(stout.toString());
+
         // trunk is a branch!
-        var branches = {
-            'trunk': '*'
-        };
-
-        var lines = stout.toString()
-        .trim()
-        .split(/[\r\n]+/);
-
-        // For each line in the refs, match only the banches
-        lines.forEach(function (line) {
-
-            var match = line.match(/\s+([0-9]+)\s.+\s([a-z0-9.]+)\//i);
-
-            if (match && match[2] !== '.') {
-                branches[match[2]] = match[1];
-            }
-        });
+        branches.trunk = '*';
 
         this._cache.branches.set(source, branches);
-
         return branches;
+
     }.bind(this));
 
     // Store the promise to be reused until it resolves
@@ -408,6 +380,25 @@ SvnResolver.branches = function (source) {
     this._cache.branches.set(source, value);
 
     return value;
+};
+
+SvnResolver.parseSubversionListOutput = function (stout) {
+
+    var entries = {};
+    var lines = stout
+        .trim()
+        .split(/[\r\n]+/);
+
+    // For each line in the refs, match only the branches
+    lines.forEach(function (line) {
+        var match = line.match(/\s+([0-9]+)\s.+\s([\w.$-]+)\//i);
+
+        if (match && match[2] !== '.') {
+            entries[match[2]] = match[1];
+        }
+    });
+
+    return entries;
 };
 
 SvnResolver.clearRuntimeCache = function () {

--- a/test/core/resolvers/svnResolver.js
+++ b/test/core/resolvers/svnResolver.js
@@ -1061,6 +1061,34 @@ describe('SvnResolver', function () {
         });
     });
 
+    describe('#parseSubversionListOutput', function () {
+
+        var list = [
+            '  12345 username              Jan 1 12:34 ./',
+            '  12346 username              Feb 2 12:34 branch-name/',
+            '  12347 username              Mar 3 12:34 branch_name/',
+            '  12348 username              Apr 4 12:34 branch.1.2.3/',
+            '  12349 username              Jun 5 12:34 BranchName/'
+        ].join('\r\n');
+
+        it('should not include the . (dot)path', function () {
+            var actual = SvnResolver.parseSubversionListOutput(list);
+
+            expect(actual).to.not.have.keys('.');
+        });
+
+        it('should parse path names with alphanumerics, dashes, dots and underscores', function () {
+            var actual = SvnResolver.parseSubversionListOutput(list);
+
+            expect(actual).to.eql({
+                'branch-name'   : '12346',
+                'branch_name'   : '12347',
+                'branch.1.2.3'  : '12348',
+                'BranchName'    : '12349'
+            });
+        });
+    });
+
     // remote resolver tests
     describe('.constructor', function () {
         it('should guess the name from the path', function () {
@@ -1107,6 +1135,9 @@ describe('SvnResolver', function () {
             })
             .done();
         });
-
     });
+
+
+
+
 });


### PR DESCRIPTION
The branch/tag checkouts were failing due to special characters - or _ in branch/tag names. This was due to the regular expression in `SvnResolver.branches` and `SvnResolver.tags` only matching alphanumerics and dots. 

This PR fixes the regex to include all valid word characters as well as dashes. Tests included.

I refactored the `svn list` output parsing to its own method to make testing easier and reduce code duplication.

This is my first real GitHub PR so let me know if I goofed up something.  
