### PR TITLE
Fix a typo in the regex trying to understand the command.

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -62,7 +62,7 @@ while (options.argv.remain.length) {
         break;
     }
 
-    command = command.replace(/s/g, '.');
+    command = command.replace(/\s/g, '.');
 
     // Direct lookup
     if (mout.object.has(bower.commands, command)) {


### PR DESCRIPTION
This is almost certainly not trying to replace 's' characters in a command and is, instead, meant to check for nested properties on `bower.commands` that were not found in `bower.abbreviations` for some reason. The kicker is that `bower.abbreviations` already contains the full command names in addition to the shortened ones, so this code path ("Direct lookup") probably never actually results in finding anything and can probably safely be removed.
