### PR TITLE
0.9.11 seems to the min node version that runs successfully

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "lib",
   "homepage": "http://bower.io",
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.9.11"
   },
   "dependencies": {
     "abbrev": "~1.0.4",


### PR DESCRIPTION
Travis build is broken with `0.8.0`. so I incrementally tested from `0.8.0` to `0.9.11` to find the working min version.

this could also be avoided by coming up with a work around to the Travis error, which is: 

`Warning: Object #<Object> has no method 'tmpdir' Use --force to continue.` in `test/core/resolvers/resolver.js:461`
