### PR TITLE
Removing compatibility with Node v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.9.11"
 before_script:
   - npm install grunt-cli -g

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "lib",
   "homepage": "http://bower.io",
   "engines": {
-    "node": ">=0.9.11"
+    "node": ">=0.10.0"
   },
   "dependencies": {
     "abbrev": "~1.0.4",


### PR DESCRIPTION
Travis builds have been broken for a while on **v0.8"

My reasoning is there is no value in making backward compatible features with **v0.8** at this point as many of the APIs are broken and will require some significant workarounds to make work with **0.8**. an effort that seems wasteful in favour on working on optimization and stability.

_Previous PR comment (for reference):_

> Travis builds have been broken for a while, it seems Node.js **v0.9.11** is the min required version for the tests to work. _(I incrementally tested from **v0.8.0** to **v0.9.11** to find the working min version)_
> 
> I've consciously upped the min-node requirement to **v0.9.11** as well to match the Travis config. my reasoning is there is no value in making backward compatible features with **v0.8** at this point as many of the apis are broken and will require some significant workarounds to make work with **0.8**. an effort that seems wasteful in favour on working on optimization and stability.
> 
> if the community has a need for **v0.8** then this would mean continuing to build workarounds, starting with the reason for this error in Travis, which is: 
> 
> `Warning: Object #<Object> has no method 'tmpdir' Use --force to continue.` in `test/core/resolvers/resolver.js:461`
