### PR TITLE
Add --production switch to "prune" command

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -21,7 +21,7 @@ function list(options, config) {
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
 
-    project.getTree()
+    project.getTree(options)
     .spread(function (tree, flattened) {
         var baseDir = path.dirname(path.join(config.cwd, config.directory));
 

--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -4,14 +4,15 @@ var Project = require('../core/Project');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
 
-function prune(config) {
+function prune(options, config) {
     var project;
     var logger = new Logger();
 
+    options = options || {};
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
 
-    clean(project)
+    clean(project, options)
     .done(function (removed) {
         logger.emit('end', removed);
     }, function (error) {
@@ -21,19 +22,19 @@ function prune(config) {
     return logger;
 }
 
-function clean(project, removed) {
+function clean(project, options, removed) {
     removed = removed || {};
 
     // Continually call clean until there is no more extraneous
     // dependencies to remove
-    return project.getTree()
+    return project.getTree(options)
     .spread(function (tree, flattened, extraneous) {
         var names = extraneous.map(function (extra) {
             return extra.endpoint.name;
         });
 
         // Uninstall extraneous
-        return project.uninstall(names)
+        return project.uninstall(names, options)
         .then(function (uninstalled) {
             // Are we done?
             if (!mout.object.size(uninstalled)) {
@@ -42,19 +43,22 @@ function clean(project, removed) {
 
             // Not yet, recurse!
             mout.object.mixIn(removed, uninstalled);
-            return clean(project, removed);
+            return clean(project, options, removed);
         });
     });
 }
 
 // -------------------
 
-prune.line = function () {
-    return prune();
+prune.line = function (argv) {
+    var options = prune.options(argv);
+    return prune(options);
 };
 
 prune.options = function (argv) {
-    return cli.readOptions(argv);
+    return cli.readOptions({
+        'production': { type: Boolean, shorthand: 'p' },
+    }, argv);
 };
 
 prune.completion = function () {

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -18,7 +18,7 @@ function uninstall(names, options, config) {
 
     tracker.trackNames('uninstall', names);
 
-    project.getTree()
+    project.getTree(options)
     .spread(function (tree, flattened) {
         // Uninstall nodes
         return project.uninstall(names, options)

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -307,7 +307,9 @@ Project.prototype.uninstall = function (names, options) {
     });
 };
 
-Project.prototype.getTree = function () {
+Project.prototype.getTree = function (options) {
+    this._options = options || {};
+
     return this._analyse()
     .spread(function (json, tree, flattened) {
         var extraneous = [];


### PR DESCRIPTION
This patch adds support for `bower prune --production`. Just like `bower install --production`, devDependencies are ignored when deciding what to prune, i.e. packages mentioned in devDependencies will be pruned.
