### PR TITLE
Improved conflict resolution message

### DIFF
--- a/templates/std/conflict-resolved.std
+++ b/templates/std/conflict-resolved.std
@@ -1,9 +1,9 @@
 {{#yellow}}Please note that,{{/yellow}}
 {{#condense}}
 {{#each picks}}
-    {{#if dependants}}{{#white}}{{dependants}}{{/white}}{{else}}none{{/if}} depend on {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#white}}{{pkgMeta._release}}{{/white}}{{/if}}
+    {{#if dependants}}{{#white}}{{dependants}}{{/white}}{{else}}none{{/if}} depends on {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#white}}{{endpoint.name}}#{{pkgMeta._release}}{{/white}}{{/if}}
 {{/each}}
 {{/condense}}
 
-Resort to using {{#cyan}}{{suitable.endpoint.name}}#{{resolution}}{{/cyan}} which resolved to {{#white}}{{suitable.pkgMeta._release}}{{/white}}
+Resort to using {{#cyan}}{{suitable.endpoint.name}}#{{resolution}}{{/cyan}} which resolved to {{#white}}{{suitable.endpoint.name}}#{{suitable.pkgMeta._release}}{{/white}}
 Code incompatibilities may occur.


### PR DESCRIPTION
This is for issue #1187

The "conflict resolved" message currently take the form: 

```
Please note that,
    bootstrap#2.3.2 depend on jquery#>=1.8.0 <2.1.0 which resolved to 2.0.3

Resort to using jquery#2.1.0 which resolved to 2.1.0
```

This PR changes "depend" to "depends" and adds the package name after "resolved to" to clear up any confusion as to which package the version number refers to. For example: 

```
Please note that,
    bootstrap#2.3.2 depends on jquery#>=1.8.0 <2.1.0 which resolved to jquery#2.0.3

Resort to using jquery#2.1.0 which resolved to jquery#2.1.0
```
