### PR TITLE
clarify uninstall warning message

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -685,7 +685,7 @@ Project.prototype._removePackages = function (packages) {
             // Delete directory
             if (!dir) {
                 promise = Q.resolve();
-                that._logger.warn('not-installed', name, {
+                that._logger.warn('not-installed', '\'' + name + '\'' + ' cannot be uninstalled as it is not currently installed', {
                     name: name
                 });
             } else {
@@ -713,7 +713,7 @@ Project.prototype._removePackages = function (packages) {
 
             promises.push(promise);
         });
-    
+
         return Q.all(promises);
 
     })


### PR DESCRIPTION
There are times when a user will try to uninstall a package that was never installed. There are a lot of reasons this could happen including the user fat-fingering the package name or not remembering that she had previously uninstalled the package or switching between codebases, etc. When the package didn't exist the warning is cryptic and unclear. This request improves the warning to read, for example: 

```
bower not-installed : bower cannot uninstall the package 'nvd3' because there is no package named 'nvd3' currently installed.
```
