### PR TITLE
Add node 0.11 to Travis, but allow it to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.11"
+matrix:
+  allow_failures:
+    - node_js: "0.11"
 before_script:
   - npm install grunt-cli -g


### PR DESCRIPTION
Node 0.12 is coming. While we don't support 0.11 it might still be useful to keep an eye on what breaks so that we can support 0.12 when it arrives.
