### PR TITLE
Tweak insight tracking for `search` command

### DIFF
--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -17,6 +17,7 @@ function search(name, config) {
 
     registryClient = new RegistryClient(config, logger);
     tracker = new Tracker(config);
+    tracker.track('search', name);
 
     // If no name was specified, list all packages
     if (!name) {
@@ -28,7 +29,6 @@ function search(name, config) {
 
     promise
     .done(function (results) {
-        tracker.track('searched', name);
         logger.emit('end', results);
     }, function (error) {
         logger.emit('error', error);


### PR DESCRIPTION
- Tracking should be consistent with `info` command; tracking should register upon user calling the command, not when the command is completed
- Vocabulary should be consistent with other tracking - if only tracking upon calling the command, should use the present tense of the verb without -"ed"

This is an improvement for tracking and reporting consistency, please see https://github.com/bower/bower/issues/1164#issuecomment-39385297
