### PR TITLE
Use SVG version of travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bower
 
-[![Build Status](https://secure.travis-ci.org/bower/bower.png?branch=master)](http://travis-ci.org/bower/bower)
+[![Build Status](https://secure.travis-ci.org/bower/bower.svg?branch=master)](http://travis-ci.org/bower/bower)
 
 <img align="right" height="300" src="http://bower.io/img/bower-logo.png">
 


### PR DESCRIPTION
SVG advantages:
- Smaller file sizes
- Scales to any size without losing clarity (except very tiny)
- Looks great on retina displays
