### PR TITLE
Loading commands on demand increases performance

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,18 +1,57 @@
+var Q = require('q');
+var Logger = require('bower-logger');
+
+/**
+ * Require commands only when called.
+ *
+ * Running `commandFactory(id)` is equivalent to `require(id)`. Both calls return
+ * a command function. The difference is that `cmd = commandFactory()` and `cmd()`
+ * return as soon as possible and load and execute the command asynchronously.
+ */
+function lazyRequire(id) {
+    function command() {
+        var logger = new Logger();
+        var commandArgs = arguments;
+
+        Q.try(function () {
+            // call require asynchronously
+            return require(id).apply(undefined, commandArgs);
+        })
+        .done(function (commandLogger) {
+            // forward to exposed logger
+            commandLogger.on('end', logger.emit.bind(logger, 'end'));
+            commandLogger.on('error', logger.emit.bind(logger, 'error'));
+        }, function (error) {
+            logger.emit('error', error);
+        });
+
+        return logger;
+    }
+
+    function runFromArgv() {
+        return require(id).line.apply(undefined, arguments);
+    }
+
+    command.line = runFromArgv;
+    return command;
+}
+
+
 module.exports = {
-    cache: require('./cache'),
-    completion: require('./completion'),
-    help: require('./help'),
-    home: require('./home'),
-    info: require('./info'),
-    init: require('./init'),
-    install: require('./install'),
-    link: require('./link'),
-    list: require('./list'),
-    lookup: require('./lookup'),
-    prune: require('./prune'),
-    register: require('./register'),
-    search: require('./search'),
-    update: require('./update'),
-    uninstall: require('./uninstall'),
-    version: require('./version')
+    cache: lazyRequire('./cache'),
+    completion: lazyRequire('./completion'),
+    help: lazyRequire('./help'),
+    home: lazyRequire('./home'),
+    info: lazyRequire('./info'),
+    init: lazyRequire('./init'),
+    install: lazyRequire('./install'),
+    link: lazyRequire('./link'),
+    list: lazyRequire('./list'),
+    lookup: lazyRequire('./lookup'),
+    prune: lazyRequire('./prune'),
+    register: lazyRequire('./register'),
+    search: lazyRequire('./search'),
+    update: lazyRequire('./update'),
+    uninstall: lazyRequire('./uninstall'),
+    version: lazyRequire('./version')
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 var abbrev = require('abbrev');
 var mout = require('mout');
 var commands = require('./commands');
-var PackageRepository = require('./core/PackageRepository');
 
 var abbreviations = abbrev(expandNames(commands));
 abbreviations.i = 'install';
@@ -30,6 +29,7 @@ function clearRuntimeCache() {
     // Note that in edge cases, some architecture components instance's
     // in-memory cache might be skipped.
     // If that's a problem, you should create and fresh instances instead.
+    var PackageRepository = require('./core/PackageRepository');
     PackageRepository.clearRuntimeCache();
 }
 


### PR DESCRIPTION
Rebased version of #1134

@sindresorhus says:

> I would rather we find the bottlenecks a fix them rather than hiding it with lazy requires.

But in fact it is a bottleneck. Commands should be loaded only when necessary. Let's iterate.

```
bower &> /dev/null  1.10s user 0.15s system 95% cpu 1.314 total
bower &> /dev/null  0.66s user 0.08s system 99% cpu 0.750 total
```

Almost every command is faster.
