### PR TITLE
using 'svn export' for efficiency. Closes #1224

### DIFF
--- a/lib/core/resolvers/SvnResolver.js
+++ b/lib/core/resolvers/SvnResolver.js
@@ -1,7 +1,5 @@
 var util = require('util');
-var path = require('path');
 var Q = require('q');
-var rimraf = require('rimraf');
 var which = require('which');
 var LRU = require('lru-cache');
 var mout = require('mout');
@@ -67,19 +65,13 @@ SvnResolver.prototype._resolve = function () {
 
     return this._findResolution()
     .then(function () {
-        return that._checkout()
-        // Always run cleanup after checkout to ensure that .svn is removed!
-        // If it's not removed, problems might arise when the "tmp" module attempts
-        // to delete the temporary folder
-        .fin(function () {
-            return that._cleanup();
-        });
+        return that._export();
     });
 };
 
 // -----------------
 
-SvnResolver.prototype._checkout = function () {
+SvnResolver.prototype._export = function () {
     var promise;
     var timer;
     var reporter;
@@ -88,19 +80,19 @@ SvnResolver.prototype._checkout = function () {
 
     this.source = SvnResolver.getSource(this._source);
 
-    this._logger.action('checkout', resolution.tag || resolution.branch || resolution.commit, {
+    this._logger.action('export', resolution.tag || resolution.branch || resolution.commit, {
         resolution: resolution,
         to: this._tempDir
     });
 
     if (resolution.type === 'commit') {
-        promise = cmd('svn', ['checkout', this._source + '/trunk', '-r' + resolution.commit, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source + '/trunk', '-r' + resolution.commit, this._tempDir]);
     } else if (resolution.type === 'branch' && resolution.branch === 'trunk') {
-        promise = cmd('svn', ['checkout', this._source + '/trunk', this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source + '/trunk', this._tempDir]);
     } else if (resolution.type === 'branch') {
-        promise = cmd('svn', ['checkout', this._source + '/branches/' + resolution.branch, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source + '/branches/' + resolution.branch, this._tempDir]);
     } else {
-        promise = cmd('svn', ['checkout', this._source + '/tags/' + resolution.tag, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source + '/tags/' + resolution.tag, this._tempDir]);
     }
 
     // Throttle the progress reporter to 1 time each sec
@@ -230,12 +222,6 @@ SvnResolver.prototype._findResolution = function (target) {
 
         throw err;
     });
-};
-
-SvnResolver.prototype._cleanup = function () {
-    var svnFolder = path.join(this._tempDir, '.svn');
-
-    return Q.nfcall(rimraf, svnFolder);
 };
 
 SvnResolver.prototype._savePkgMeta = function (meta) {


### PR DESCRIPTION
based on suggestion from @asapach

using `svn export` is speedier and more efficient than `svn checkout`
