### PR TITLE
Fix considering extended directory using .bowerrc

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -23,8 +23,6 @@ function list(options, config) {
 
     project.getTree(options)
     .spread(function (tree, flattened) {
-        var baseDir = path.dirname(path.join(config.cwd, config.directory));
-
         // Relativize paths
         // Also normalize paths on windows
         project.walkTree(tree, function (node) {
@@ -33,7 +31,7 @@ function list(options, config) {
             }
 
             if (options.relative) {
-                node.canonicalDir = path.relative(baseDir, node.canonicalDir);
+                node.canonicalDir = path.relative(config.cwd, node.canonicalDir);
             }
             if (options.paths) {
                 node.canonicalDir = normalize(node.canonicalDir);
@@ -48,7 +46,7 @@ function list(options, config) {
             }
 
             if (options.relative) {
-                node.canonicalDir = path.relative(baseDir, node.canonicalDir);
+                node.canonicalDir = path.relative(config.cwd, node.canonicalDir);
             }
             if (options.paths) {
                 node.canonicalDir = normalize(node.canonicalDir);


### PR DESCRIPTION
Rebased and cleaned up version of #942. I can really see this is considered a bug.

```
cat .bowerrc
{
    "directory": "app/assets/components"
}
bower install angular-bootstrap
```

Before: 

```
bower list -p
{
  "angular-bootstrap": "components/angular-bootstrap/ui-bootstrap-tpls.js",
  "angular": "components/angular/angular.js"
}
bower list -p --relative=false
{
  "angular-bootstrap": "/Users/sheerun/Source/bower/app/assets/components/angular-bootstrap/ui-bootstrap-tpls.js",
  "angular": "/Users/sheerun/Source/bower/app/assets/components/angular/angular.js"
}
```

After:

```
bower list -p
{
  "angular-bootstrap": "app/assets/components/angular-bootstrap/ui-bootstrap-tpls.js",
  "angular": "app/assets/components/angular/angular.js"
}
bower list -p --relative=false
{
  "angular-bootstrap": "/Users/sheerun/Source/bower/app/assets/components/angular-bootstrap/ui-bootstrap-tpls.js",
  "angular": "/Users/sheerun/Source/bower/app/assets/components/angular/angular.js"
}
```

After fix it behaves the same if `config.directory` is not specified.
