### PR TITLE
Improve noninteractive loading performance 2x, fixes #1221

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -5,7 +5,6 @@ process.bin = process.title = 'bower';
 var Q = require('q');
 var path = require('path');
 var mout = require('mout');
-var updateNotifier = require('update-notifier');
 var Logger = require('bower-logger');
 var osenv = require('osenv');
 var bower = require('../lib');
@@ -73,7 +72,7 @@ while (options.argv.remain.length) {
 }
 
 // Ask for Insights on first run.
-analytics.setup().then(function () {
+analytics.setup(bower.config).then(function () {
     // Execute the command
     commandFunc = command && mout.object.get(bower.commands, command);
     command = command && command.replace(/\./g, ' ');
@@ -133,13 +132,17 @@ analytics.setup().then(function () {
         logger.warn('no-home', 'HOME not set, user configuration will not be loaded');
     }
 
-    // Check for newer version of Bower
-    notifier = updateNotifier({
-        packageName: pkg.name,
-        packageVersion: pkg.version
-    });
+    if (bower.config.interactive) {
+        var updateNotifier = require('update-notifier');
 
-    if (notifier.update && levels.info >= loglevel) {
-        renderer.updateNotice(notifier.update);
+        // Check for newer version of Bower
+        notifier = updateNotifier({
+            packageName: pkg.name,
+            packageVersion: pkg.version
+        });
+
+        if (notifier.update && levels.info >= loglevel) {
+            renderer.updateNotice(notifier.update);
+        }
     }
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,14 +9,18 @@ delete config.json;
 
 // If interactive is auto (null), guess its value
 if (config.interactive == null) {
-    config.interactive = process.bin === 'bower' && tty.isatty(1);
+    config.interactive = (
+        process.bin === 'bower' &&
+        tty.isatty(1) &&
+        !process.env.CI
+    );
 }
 
 // If `analytics` hasn't been explicitly set, we disable
 // it when ran programatically.
 if (config.analytics == null) {
     // Don't enable analytics on CI server unless explicitly configured.
-    config.analytics = config.interactive && !process.env.CI;
+    config.analytics = config.interactive;
 }
 
 // Merge common CLI options into the config

--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -1,10 +1,8 @@
-var cardinal = require('cardinal');
 var chalk = require('chalk');
 var path = require('path');
 var mout = require('mout');
 var archy = require('archy');
 var Q = require('q');
-var inquirer = require('inquirer');
 var stringifyObject = require('stringify-object');
 var os = require('os');
 var pkg = require(path.join(__dirname, '../..', 'package.json'));
@@ -106,6 +104,7 @@ StandardRenderer.prototype.prompt = function (prompts) {
 
     // Prompt
     deferred = Q.defer();
+    var inquirer = require('inquirer');
     inquirer.prompt(prompts, deferred.resolve);
 
     return deferred.promise;
@@ -394,6 +393,8 @@ StandardRenderer.prototype._write = function (stream, str) {
 };
 
 StandardRenderer.prototype._highlightJson = function (json) {
+    var cardinal = require('cardinal');
+
     return cardinal.highlight(stringifyObject(json, { indent: '  ' }), {
         theme: {
             String: {

--- a/lib/util/analytics.js
+++ b/lib/util/analytics.js
@@ -1,26 +1,31 @@
 var Q = require('q');
-var Insight = require('insight');
 var mout = require('mout');
-var config = require('../config');
-var pkg = require('../../package.json');
 
 var analytics = module.exports;
 var insight;
 
 // Initializes the application-wide insight singleton and asks for the
 // permission on the CLI during the first run.
-analytics.setup = function setup() {
+analytics.setup = function setup(config) {
     var deferred = Q.defer();
-    insight = new Insight({
-        trackingCode: 'UA-43531210-1',
-        packageName: pkg.name,
-        packageVersion: pkg.version
-    });
 
     // Display the ask prompt only if it hasn't been answered before
     // and the current session is looking to configure the analytics.
-    if (insight.optOut === undefined && config.analytics) {
-        insight.askPermission(null, deferred.resolve);
+    if (config.analytics) {
+        var Insight = require('insight');
+        var pkg = require('../../package.json');
+
+        insight = new Insight({
+            trackingCode: 'UA-43531210-1',
+            packageName: pkg.name,
+            packageVersion: pkg.version
+        });
+
+        if (insight.optOut === undefined) {
+            insight.askPermission(null, deferred.resolve);
+        } else {
+            deferred.resolve();
+        }
     } else {
         deferred.resolve();
     }


### PR DESCRIPTION
I selected slowest components and postponed their `require`.

Also, I don't load components not needed in non-interactive mode.

Before:

```
time bower --config.interactive=false
bower --config.interactive=false  0.58s user 0.07s system 99% cpu 0.656 total
```

After:

```
time bower --config.interactive=false
bower --config.interactive=false  0.30s user 0.04s system 98% cpu 0.346 total
```

This commit also fixes #1221 and #1162 by disabling interactive mode if `CI` is true.
