### PR TITLE
Use promise interface for commands

### DIFF
--- a/lib/commands/cache/clean.js
+++ b/lib/commands/cache/clean.js
@@ -3,15 +3,13 @@ var path = require('path');
 var mout = require('mout');
 var Q = require('q');
 var rimraf = require('rimraf');
-var Logger = require('bower-logger');
 var endpointParser = require('bower-endpoint-parser');
 var PackageRepository = require('../../core/PackageRepository');
 var semver = require('../../util/semver');
 var cli = require('../../util/cli');
 var defaultConfig = require('../../config');
 
-function clean(endpoints, options, config) {
-    var logger = new Logger();
+function clean(logger, endpoints, options, config) {
     var decEndpoints;
     var names;
 
@@ -33,21 +31,14 @@ function clean(endpoints, options, config) {
         });
     }
 
-    Q.all([
+    return Q.all([
         clearPackages(decEndpoints, config, logger),
         clearLinks(names, config, logger),
         !names ? clearCompletion(config, logger) : null
     ])
     .spread(function (entries) {
         return entries;
-    })
-    .done(function (entries) {
-        logger.emit('end', entries);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 function clearPackages(decEndpoints, config, logger) {
@@ -201,13 +192,10 @@ function clearCompletion(config, logger) {
 
 // -------------------
 
-clean.line = function (argv) {
-    var options = clean.options(argv);
-    return clean(options.argv.remain.slice(2), options);
-};
-
-clean.options = function (argv) {
-    return cli.readOptions(argv);
+clean.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
+    var endpoints = options.argv.remain.slice(2);
+    return clean(logger, endpoints, options);
 };
 
 clean.completion = function () {

--- a/lib/commands/cache/list.js
+++ b/lib/commands/cache/list.js
@@ -1,12 +1,10 @@
 var mout = require('mout');
-var Logger = require('bower-logger');
 var PackageRepository = require('../../core/PackageRepository');
 var cli = require('../../util/cli');
 var defaultConfig = require('../../config');
 
-function list(packages, options, config) {
+function list(logger, packages, options, config) {
     var repository;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     repository = new PackageRepository(config, logger);
@@ -16,7 +14,7 @@ function list(packages, options, config) {
         packages = null;
     }
 
-    repository.list()
+    return repository.list()
     .then(function (entries) {
         if (packages) {
             // Filter entries according to the specified packages
@@ -28,25 +26,15 @@ function list(packages, options, config) {
         }
 
         return entries;
-    })
-    .done(function (entries) {
-        logger.emit('end', entries);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 // -------------------
 
-list.line = function (argv) {
-    var options = list.options(argv);
-    return list(options.argv.remain.slice(2), options);
-};
-
-list.options = function (argv) {
-    return cli.readOptions(argv);
+list.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
+    var packages = options.argv.remain.slice(2);
+    return list(logger, packages, options);
 };
 
 list.completion = function () {

--- a/lib/commands/completion.js
+++ b/lib/commands/completion.js
@@ -1,27 +1,17 @@
-var Logger = require('bower-logger');
+var Q = require('q');
 var cli = require('../util/cli');
 
 function completion(config) {
-    var logger = new Logger();
-
-    process.nextTick(function () {
-        logger.emit('end');
-    });
-
-    return logger;
+    return new Q();
 }
 
 // -------------------
 
-completion.line = function (argv) {
-    var options = completion.options(argv);
+completion.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
     var name = options.argv.remain[1];
 
-    return completion(name);
-};
-
-completion.options = function (argv) {
-    return cli.readOptions(argv);
+    return completion(logger, name);
 };
 
 completion.completion = function () {

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -1,12 +1,11 @@
+var Q = require('q');
 var path = require('path');
 var fs = require('graceful-fs');
-var Logger = require('bower-logger');
 var cli = require('../util/cli');
 var createError = require('../util/createError');
 
-function help(name) {
+function help(logger, name) {
     var json;
-    var logger = new Logger();
 
     if (name) {
         json = path.resolve(__dirname, '../../templates/json/help-' + name.replace(/\s+/g, '/') + '.json');
@@ -14,35 +13,26 @@ function help(name) {
         json = path.resolve(__dirname, '../../templates/json/help.json');
     }
 
-    fs.exists(json, function (exists) {
+    return Q.promise(function (resolve) {
+        fs.exists(json, resolve);
+    })
+    .then(function (exists) {
         if (!exists) {
-            return logger.emit('error', createError('Unknown command: ' + name, 'EUNKOWNCMD', {
+            throw createError('Unknown command: ' + name, 'EUNKOWNCMD', {
                 command: name
-            }));
+            });
         }
 
-        try {
-            json = require(json);
-        } catch (error) {
-            return logger.emit('error', error);
-        }
-
-        logger.emit('end', json);
+        return require(json);
     });
-
-    return logger;
 }
 
 // -------------------
 
-help.line = function (argv) {
-    var options = help.options(argv);
-
-    return help(options.argv.remain.slice(1).join(' '));
-};
-
-help.options = function (argv) {
-    return cli.readOptions(argv);
+help.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
+    var name = options.argv.remain.slice(1).join(' ');
+    return help(logger, name);
 };
 
 help.completion = function () {

--- a/lib/commands/home.js
+++ b/lib/commands/home.js
@@ -1,5 +1,4 @@
 var mout = require('mout');
-var Logger = require('bower-logger');
 var Project = require('../core/Project');
 var open = require('open');
 var endpointParser = require('bower-endpoint-parser');
@@ -7,11 +6,10 @@ var cli = require('../util/cli');
 var createError = require('../util/createError');
 var defaultConfig = require('../config');
 
-function home(name, config) {
+function home(logger, name, config) {
     var project;
     var promise;
     var decEndpoint;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
@@ -37,7 +35,7 @@ function home(name, config) {
     }
 
     // Get homepage and open it
-    promise.then(function (pkgMeta) {
+    return promise.then(function (pkgMeta) {
         var homepage = pkgMeta.homepage;
 
         if (!homepage) {
@@ -46,27 +44,16 @@ function home(name, config) {
 
         open(homepage);
         return homepage;
-    })
-    .done(function (homepage) {
-        logger.emit('end', homepage);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 // -------------------
 
-home.line = function (argv) {
-    var options = home.options(argv);
+home.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
     var name = options.argv.remain[1];
 
-    return home(name);
-};
-
-home.options = function (argv) {
-    return cli.readOptions(argv);
+    return home(logger, name);
 };
 
 home.completion = function () {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -8,19 +8,30 @@ var Logger = require('bower-logger');
  * a command function. The difference is that `cmd = commandFactory()` and `cmd()`
  * return as soon as possible and load and execute the command asynchronously.
  */
-function lazyRequire(id) {
+function commandFactory(id) {
     function command() {
-        var logger = new Logger();
-        var commandArgs = arguments;
+        var commandArgs = [].slice.call(arguments);
 
-        Q.try(function () {
-            // call require asynchronously
+        return withLogger(function (logger) {
+            commandArgs.unshift(logger);
             return require(id).apply(undefined, commandArgs);
-        })
-        .done(function (commandLogger) {
-            // forward to exposed logger
-            commandLogger.on('end', logger.emit.bind(logger, 'end'));
-            commandLogger.on('error', logger.emit.bind(logger, 'error'));
+        });
+    }
+
+    function runFromArgv(argv) {
+        return withLogger(function (logger) {
+            return require(id).line.call(undefined, logger, argv);
+        });
+    }
+
+    function withLogger(func) {
+        var logger = new Logger();
+
+        Q.try(func, logger)
+        .done(function () {
+            var args = [].slice.call(arguments);
+            args.unshift('end');
+            logger.emit.apply(logger, args);
         }, function (error) {
             logger.emit('error', error);
         });
@@ -28,34 +39,29 @@ function lazyRequire(id) {
         return logger;
     }
 
-    function runFromArgv() {
-        return require(id).line.apply(undefined, arguments);
-    }
-
     command.line = runFromArgv;
-
     return command;
 }
 
 
 module.exports = {
     cache: {
-        clean: lazyRequire('./cache/clean'),
-        list: lazyRequire('./cache/list')
+        clean: commandFactory('./cache/clean'),
+        list: commandFactory('./cache/list'),
     },
-    completion: lazyRequire('./completion'),
-    help: lazyRequire('./help'),
-    home: lazyRequire('./home'),
-    info: lazyRequire('./info'),
-    init: lazyRequire('./init'),
-    install: lazyRequire('./install'),
-    link: lazyRequire('./link'),
-    list: lazyRequire('./list'),
-    lookup: lazyRequire('./lookup'),
-    prune: lazyRequire('./prune'),
-    register: lazyRequire('./register'),
-    search: lazyRequire('./search'),
-    update: lazyRequire('./update'),
-    uninstall: lazyRequire('./uninstall'),
-    version: lazyRequire('./version')
+    completion: commandFactory('./completion'),
+    help: commandFactory('./help'),
+    home: commandFactory('./home'),
+    info: commandFactory('./info'),
+    init: commandFactory('./init'),
+    install: commandFactory('./install'),
+    link: commandFactory('./link'),
+    list: commandFactory('./list'),
+    lookup: commandFactory('./lookup'),
+    prune: commandFactory('./prune'),
+    register: commandFactory('./register'),
+    search: commandFactory('./search'),
+    update: commandFactory('./update'),
+    uninstall: commandFactory('./uninstall'),
+    version: commandFactory('./version')
 };

--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -1,17 +1,15 @@
 var mout = require('mout');
 var Q = require('q');
-var Logger = require('bower-logger');
 var endpointParser = require('bower-endpoint-parser');
 var PackageRepository = require('../core/PackageRepository');
 var cli = require('../util/cli');
 var Tracker = require('../util/analytics').Tracker;
 var defaultConfig = require('../config');
 
-function info(endpoint, property, config) {
+function info(logger, endpoint, property, config) {
     var repository;
     var decEndpoint;
     var tracker;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     repository = new PackageRepository(config, logger);
@@ -20,7 +18,7 @@ function info(endpoint, property, config) {
     decEndpoint = endpointParser.decompose(endpoint);
     tracker.trackDecomposedEndpoints('info', [decEndpoint]);
 
-    Q.all([
+    return Q.all([
         getPkgMeta(repository, decEndpoint, property),
         decEndpoint.target === '*' && !property ? repository.versions(decEndpoint.source) : null
     ])
@@ -34,14 +32,7 @@ function info(endpoint, property, config) {
         }
 
         return pkgMeta;
-    })
-    .done(function (result) {
-        logger.emit('end', result);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 function getPkgMeta(repository, decEndpoint, property) {
@@ -62,20 +53,16 @@ function getPkgMeta(repository, decEndpoint, property) {
 
 // -------------------
 
-info.line = function (argv) {
-    var options = info.options(argv);
+info.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
     var pkg = options.argv.remain[1];
     var property = options.argv.remain[2];
 
     if (!pkg) {
-        return null;
+        return new Q(null);
     }
 
     return info(pkg, property);
-};
-
-info.options = function (argv) {
-    return cli.readOptions(argv);
 };
 
 info.completion = function () {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -2,7 +2,6 @@ var mout = require('mout');
 var fs = require('graceful-fs');
 var path = require('path');
 var Q = require('q');
-var Logger = require('bower-logger');
 var endpointParser = require('bower-endpoint-parser');
 var Project = require('../core/Project');
 var defaultConfig = require('../config');
@@ -12,9 +11,8 @@ var cli = require('../util/cli');
 var cmd = require('../util/cmd');
 var createError = require('../util/createError');
 
-function init(config) {
+function init(logger, config) {
     var project;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
 
@@ -31,7 +29,7 @@ function init(config) {
     project = new Project(config, logger);
 
     // Start with existing JSON details
-    readJson(project, logger)
+    return readJson(project, logger)
     // Fill in defaults
     .then(setDefaults.bind(null, config))
     // Now prompt user to make changes
@@ -41,14 +39,7 @@ function init(config) {
     // Set dependencies based on the response
     .spread(setDependencies.bind(null, project))
     // All done!
-    .spread(saveJson.bind(null, project, logger))
-    .done(function (json) {
-        logger.emit('end', json);
-    }, function (error) {
-        logger.emit('error', error);
-    });
-
-    return logger;
+    .spread(saveJson.bind(null, project, logger));
 }
 
 function readJson(project, logger) {
@@ -329,12 +320,9 @@ function setDependencies(project, json, answers) {
 
 // -------------------
 
-init.line = function () {
-    return init();
-};
-
-init.options = function (argv) {
-    return cli.readOptions(argv);
+init.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
+    return init(logger, options);
 };
 
 init.completion = function () {

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,16 +1,14 @@
 var mout = require('mout');
-var Logger = require('bower-logger');
 var endpointParser = require('bower-endpoint-parser');
 var Project = require('../core/Project');
 var cli = require('../util/cli');
 var Tracker = require('../util/analytics').Tracker;
 var defaultConfig = require('../config');
 
-function install(endpoints, options, config) {
+function install(logger, endpoints, options, config) {
     var project;
     var decEndpoints;
     var tracker;
-    var logger = new Logger();
 
     options = options || {};
     config = mout.object.deepFillIn(config || {}, defaultConfig);
@@ -27,22 +25,14 @@ function install(endpoints, options, config) {
     });
     tracker.trackDecomposedEndpoints('install', decEndpoints);
 
-    project.install(decEndpoints, options)
-    .done(function (installed) {
-        tracker.trackPackages('installed', installed);
-        logger.emit('end', installed);
-    }, function (error) {
-        logger.emit('error', error);
-    });
-
-    return logger;
+    return project.install(decEndpoints, options);
 }
 
 // -------------------
 
-install.line = function (argv) {
+install.line = function (logger, argv) {
     var options = install.options(argv);
-    return install(options.argv.remain.slice(1), options);
+    return install(logger, options.argv.remain.slice(1), options);
 };
 
 install.options = function (argv) {

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -2,20 +2,26 @@ var path = require('path');
 var rimraf = require('rimraf');
 var mout = require('mout');
 var Q = require('q');
-var Logger = require('bower-logger');
 var Project = require('../core/Project');
 var createLink = require('../util/createLink');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
 
-function linkSelf(config) {
+function link(logger, name, localName) {
+    if (name) {
+        return linkTo(logger, name, localName);
+    } else {
+        return linkSelf(logger);
+    }
+}
+
+function linkSelf(logger, config) {
     var project;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
 
-    project.getJson()
+    return project.getJson()
     .then(function (json) {
         var src = config.cwd;
         var dst = path.join(config.storage.links, json.name);
@@ -32,20 +38,12 @@ function linkSelf(config) {
                 dst: dst
             };
         });
-    })
-    .done(function (result) {
-        logger.emit('end', result);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
-function linkTo(name, localName, config) {
+function linkTo(logger, name, localName, config) {
     var src;
     var dst;
-    var logger = new Logger();
     var project = new Project(config, logger);
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
@@ -55,7 +53,7 @@ function linkTo(name, localName, config) {
     dst = path.join(process.cwd(), config.directory, localName);
 
     // Delete destination folder if any
-    Q.nfcall(rimraf, dst)
+    return Q.nfcall(rimraf, dst)
     // Link locally
     .then(function () {
         return createLink(src, dst);
@@ -70,37 +68,16 @@ function linkTo(name, localName, config) {
             dst: dst,
             installed: installed
         };
-    })
-    .done(function (result) {
-        logger.emit('end', result);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 // -------------------
 
-var link = {
-    linkTo: linkTo,
-    linkSelf: linkSelf
-};
-
-link.line = function (argv) {
-    var options = link.options(argv);
+link.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
     var name = options.argv.remain[1];
     var localName = options.argv.remain[2];
-
-    if (name) {
-        return linkTo(name, localName);
-    }
-
-    return linkSelf();
-};
-
-link.options = function (argv) {
-    return cli.readOptions(argv);
+    return link(logger, name, localName);
 };
 
 link.completion = function () {

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -1,15 +1,13 @@
 var path = require('path');
 var mout = require('mout');
 var Q = require('q');
-var Logger = require('bower-logger');
 var Project = require('../core/Project');
 var semver = require('../util/semver');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
 
-function list(options, config) {
+function list(logger, options, config) {
     var project;
-    var logger = new Logger();
 
     options = options || {};
 
@@ -21,7 +19,9 @@ function list(options, config) {
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
 
-    project.getTree(options)
+    logger.json = !!options.paths;
+
+    return project.getTree(options)
     .spread(function (tree, flattened) {
         // Relativize paths
         // Also normalize paths on windows
@@ -68,16 +68,7 @@ function list(options, config) {
         .then(function () {
             return tree;
         });
-    })
-    .done(function (value) {
-        logger.emit('end', value);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    logger.json = !!options.paths;
-
-    return logger;
 }
 
 function checkVersions(project, tree, logger) {
@@ -162,9 +153,9 @@ function normalize(src) {
 
 // -------------------
 
-list.line = function (argv) {
+list.line = function (logger, argv) {
     var options = list.options(argv);
-    return list(options);
+    return list(logger, options);
 };
 
 list.options = function (argv) {

--- a/lib/commands/lookup.js
+++ b/lib/commands/lookup.js
@@ -1,20 +1,18 @@
 var mout = require('mout');
 var Q = require('q');
-var Logger = require('bower-logger');
 var RegistryClient = require('bower-registry-client');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
 
-function lookup(name, config) {
+function lookup(logger, name, config) {
     var registryClient;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     config.cache = config.storage.registry;
 
     registryClient = new RegistryClient(config, logger);
 
-    Q.nfcall(registryClient.lookup.bind(registryClient), name)
+    return Q.nfcall(registryClient.lookup.bind(registryClient), name)
     .then(function (entry) {
         // TODO: Handle entry.type.. for now it's only 'alias'
         //       When we got published packages, this needs to be adjusted
@@ -22,31 +20,20 @@ function lookup(name, config) {
             name: name,
             url: entry && entry.url
         };
-    })
-    .done(function (result) {
-        logger.emit('end', result);
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 // -------------------
 
-lookup.line = function (argv) {
-    var options = lookup.options(argv);
+lookup.line = function (logger, argv) {
+    var options =  cli.readOptions(argv);
     var name = options.argv.remain[1];
 
     if (!name) {
-        return null;
+        return new Q(null);
+    } else {
+        return lookup(logger, name);
     }
-
-    return lookup(name);
-};
-
-lookup.options = function (argv) {
-    return cli.readOptions(argv);
 };
 
 lookup.completion = function () {

--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -1,25 +1,16 @@
 var mout = require('mout');
-var Logger = require('bower-logger');
 var Project = require('../core/Project');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
 
-function prune(options, config) {
+function prune(logger, options, config) {
     var project;
-    var logger = new Logger();
 
     options = options || {};
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
 
-    clean(project, options)
-    .done(function (removed) {
-        logger.emit('end', removed);
-    }, function (error) {
-        logger.emit('error', error);
-    });
-
-    return logger;
+    return clean(project, options);
 }
 
 function clean(project, options, removed) {
@@ -50,9 +41,9 @@ function clean(project, options, removed) {
 
 // -------------------
 
-prune.line = function (argv) {
+prune.line = function (logger, argv) {
     var options = prune.options(argv);
-    return prune(options);
+    return prune(logger, options);
 };
 
 prune.options = function (argv) {

--- a/lib/commands/register.js
+++ b/lib/commands/register.js
@@ -2,7 +2,6 @@ var mout = require('mout');
 var Q = require('q');
 var chalk = require('chalk');
 var PackageRepository = require('../core/PackageRepository');
-var Logger = require('bower-logger');
 var Config = require('bower-config');
 var Tracker = require('../util/analytics').Tracker;
 var cli = require('../util/cli');
@@ -10,11 +9,10 @@ var createError = require('../util/createError');
 var defaultConfig = require('../config');
 var GitHubResolver = require('../core/resolvers/GitHubResolver');
 
-function register(name, url, config) {
+function register(logger, name, url, config) {
     var repository;
     var registryClient;
     var tracker;
-    var logger = new Logger();
     var force;
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
@@ -28,11 +26,11 @@ function register(name, url, config) {
     // Trim name
     name = name.trim();
 
-    process.nextTick(function () {
+    return Q.try(function () {
         // Verify name
         // TODO: Verify with the new spec regexp?
         if (!name) {
-            return logger.emit('error', createError('Please type a name', 'EINVNAME'));
+            throw createError('Please type a name', 'EINVNAME');
         }
 
         // The public registry only allows git:// endpoints
@@ -41,7 +39,7 @@ function register(name, url, config) {
             url = convertUrl(url, logger);
 
             if (!mout.string.startsWith(url, 'git://')) {
-                return logger.emit('error', createError('The registry only accepts URLs starting with git://', 'EINVFORMAT'));
+                throw createError('The registry only accepts URLs starting with git://', 'EINVFORMAT');
             }
         }
 
@@ -50,50 +48,42 @@ function register(name, url, config) {
         // Attempt to resolve the package referenced by the URL to ensure
         // everything is ok before registering
         repository = new PackageRepository(config, logger);
-        repository.fetch({ name: name, source: url, target: '*' })
-        .spread(function (canonicalDir, pkgMeta) {
-            if (pkgMeta.private) {
-                throw createError('The package you are trying to register is marked as private', 'EPRIV');
-            }
+        return repository.fetch({ name: name, source: url, target: '*' });
+    })
+    .spread(function (canonicalDir, pkgMeta) {
+        if (pkgMeta.private) {
+            throw createError('The package you are trying to register is marked as private', 'EPRIV');
+        }
 
-            // If non interactive or user forced, bypass confirmation
-            if (!config.interactive || force) {
-                return true;
-            }
+        // If non interactive or user forced, bypass confirmation
+        if (!config.interactive || force) {
+            return true;
+        }
 
-            // Confirm if the user really wants to register
-            return Q.nfcall(logger.prompt.bind(logger), {
-                type: 'confirm',
-                message: 'Registering a package will make it installable via the registry (' +
-                    chalk.cyan.underline(config.registry.register) + '), continue?',
-                default: true
-            });
-        })
-        .then(function (result) {
-            // If user response was negative, abort
-            if (!result) {
-                return;
-            }
-
-            // Register
-            registryClient = repository.getRegistryClient();
-
-            logger.action('register', url, {
-                name: name,
-                url: url
-            });
-
-            return Q.nfcall(registryClient.register.bind(registryClient), name, url);
-        })
-        .done(function (result) {
-            tracker.track('registered');
-            logger.emit('end', result);
-        }, function (error) {
-            logger.emit('error', error);
+        // Confirm if the user really wants to register
+        return Q.nfcall(logger.prompt.bind(logger), {
+            type: 'confirm',
+            message: 'Registering a package will make it installable via the registry (' +
+                chalk.cyan.underline(config.registry.register) + '), continue?',
+            default: true
         });
-    });
+    })
+    .then(function (result) {
+        // If user response was negative, abort
+        if (!result) {
+            return;
+        }
 
-    return logger;
+        // Register
+        registryClient = repository.getRegistryClient();
+
+        logger.action('register', url, {
+            name: name,
+            url: url
+        });
+
+        return Q.nfcall(registryClient.register.bind(registryClient), name, url);
+    });
 }
 
 function convertUrl(url, logger) {
@@ -114,20 +104,16 @@ function convertUrl(url, logger) {
 
 // -------------------
 
-register.line = function (argv) {
-    var options = register.options(argv);
+register.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
     var name = options.argv.remain[1];
     var url = options.argv.remain[2];
 
     if (!name || !url) {
-        return null;
+        return new Q(null);
+    } else {
+        return register(logger, name, url);
     }
-
-    return register(name, url);
-};
-
-register.options = function (argv) {
-    return cli.readOptions(argv);
 };
 
 register.completion = function () {

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -1,16 +1,13 @@
 var mout = require('mout');
 var Q = require('q');
-var Logger = require('bower-logger');
 var RegistryClient = require('bower-registry-client');
 var cli = require('../util/cli');
 var Tracker = require('../util/analytics').Tracker;
 var defaultConfig = require('../config');
 
-function search(name, config) {
+function search(logger, name, config) {
     var registryClient;
-    var promise;
     var tracker;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     config.cache = config.storage.registry;
@@ -21,31 +18,19 @@ function search(name, config) {
 
     // If no name was specified, list all packages
     if (!name) {
-        promise = Q.nfcall(registryClient.list.bind(registryClient));
+        return Q.nfcall(registryClient.list.bind(registryClient));
     // Otherwise search it
     } else {
-        promise = Q.nfcall(registryClient.search.bind(registryClient), name);
+        return Q.nfcall(registryClient.search.bind(registryClient), name);
     }
-
-    promise
-    .done(function (results) {
-        logger.emit('end', results);
-    }, function (error) {
-        logger.emit('error', error);
-    });
-
-    return logger;
 }
 
 // -------------------
 
-search.line = function (argv) {
-    var options = search.options(argv);
-    return search(options.argv.remain.slice(1).join(' '), options);
-};
-
-search.options = function (argv) {
-    return cli.readOptions(argv);
+search.line = function (logger, argv) {
+    var options = cli.readOptions(argv);
+    var name = options.argv.remain.slice(1).join(' ');
+    return search(logger, name, options);
 };
 
 search.completion = function () {

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -1,15 +1,13 @@
 var mout = require('mout');
-var Logger = require('bower-logger');
 var Q = require('q');
 var Project = require('../core/Project');
 var cli = require('../util/cli');
 var Tracker = require('../util/analytics').Tracker;
 var defaultConfig = require('../config');
 
-function uninstall(names, options, config) {
+function uninstall(logger, names, options, config) {
     var project;
     var tracker;
-    var logger = new Logger();
 
     options = options || {};
     config = mout.object.deepFillIn(config || {}, defaultConfig);
@@ -18,7 +16,7 @@ function uninstall(names, options, config) {
 
     tracker.trackNames('uninstall', names);
 
-    project.getTree(options)
+    return project.getTree(options)
     .spread(function (tree, flattened) {
         // Uninstall nodes
         return project.uninstall(names, options)
@@ -37,15 +35,7 @@ function uninstall(names, options, config) {
             // Clean them!
             return clean(project, children, uninstalled);
         });
-    })
-    .done(function (uninstalled) {
-        logger.emit('end', uninstalled);
-        tracker.trackNames('uninstalled', Object.keys(uninstalled));
-    }, function (error) {
-        logger.emit('error', error);
     });
-
-    return logger;
 }
 
 function clean(project, names, removed) {
@@ -109,15 +99,15 @@ function clean(project, names, removed) {
 
 // -------------------
 
-uninstall.line = function (argv) {
+uninstall.line = function (logger, argv) {
     var options = uninstall.options(argv);
     var names = options.argv.remain.slice(1);
 
     if (!names.length) {
-        return null;
+        return new Q(null);
+    } else {
+        return uninstall(logger, names, options);
     }
-
-    return uninstall(names, options);
 };
 
 uninstall.options = function (argv) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -1,12 +1,10 @@
 var mout = require('mout');
-var Logger = require('bower-logger');
 var Project = require('../core/Project');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
 
-function update(names, options, config) {
+function update(logger, names, options, config) {
     var project;
-    var logger = new Logger();
 
     options = options || {};
     config = mout.object.deepFillIn(config || {}, defaultConfig);
@@ -17,21 +15,15 @@ function update(names, options, config) {
         names = null;
     }
 
-    project.update(names, options)
-    .done(function (installed) {
-        logger.emit('end', installed);
-    }, function (error) {
-        logger.emit('error', error);
-    });
-
-    return logger;
+    return project.update(names, options);
 }
 
 // -------------------
 
-update.line = function (argv) {
+update.line = function (logger, argv) {
     var options = update.options(argv);
-    return update(options.argv.remain.slice(1), options);
+    var names = options.argv.remain.slice(1);
+    return update(logger, names, options);
 };
 
 update.options = function (argv) {

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -1,6 +1,5 @@
 var mout = require('mout');
 var semver = require('semver');
-var Logger = require('bower-logger');
 var which = require('which');
 var fs = require('fs');
 var path = require('path');
@@ -11,21 +10,13 @@ var cli = require('../util/cli');
 var defaultConfig = require('../config');
 var createError = require('../util/createError');
 
-function version(versionArg, options, config) {
+function version(logger, versionArg, options, config) {
     var project;
-    var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
 
-    bump(project, versionArg, options.message)
-    .done(function () {
-        logger.emit('end');
-    }, function (error) {
-        logger.emit('error', error);
-    });
-
-    return logger;
+    return bump(project, versionArg, options.message);
 }
 
 function bump(project, versionArg, message) {
@@ -122,9 +113,9 @@ function gitCommitAndTag(newVersion, message) {
 
 // -------------------
 
-version.line = function (argv) {
+version.line = function (logger, argv) {
     var options = version.options(argv);
-    return version(options.argv.remain[1], options);
+    return version(logger, options.argv.remain[1], options);
 };
 
 version.options = function (argv) {


### PR DESCRIPTION
This commit changes the interface of the command functions exported by the files in `lib/commands`. The functions now return a promise and accept a logger as the first argument. This has several advantages.
- The promise style is consistent with the rest of the code.
- It removes a lot of duplicate code.
- The command factory does not need to proxy the logger object.

Follow up to #1134 and #1232.
