### PR TITLE
Work in the root of the current project, rather than in the current path

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -11,12 +11,23 @@ var cli = require('../util/cli');
 var defaultConfig = require('../config');
 var createError = require('../util/createError');
 
+var rootDir;
+
+var git = function (args) {
+    return Q.nfcall(execFile, 'git', args, {
+        env: process.env,
+        cwd: rootDir
+    });
+};
+
 function version(versionArg, options, config) {
     var project;
     var logger = new Logger();
 
     config = mout.object.deepFillIn(config || {}, defaultConfig);
     project = new Project(config, logger);
+
+    rootDir = project.getRootDir();
 
     bump(project, versionArg, options.message)
     .done(function () {
@@ -66,8 +77,8 @@ function getNewVersion(currentVersion, versionArg) {
     return newVersion;
 }
 
-function checkGit() {
-    var gitDir = path.join(process.cwd(), '.git');
+function checkGit(rootDir) {
+    var gitDir = path.join(rootDir, '.git');
     return Q.nfcall(fs.stat, gitDir)
     .then(function (stat) {
         if (stat.isDirectory()) {
@@ -87,7 +98,7 @@ function checkGitStatus() {
         throw err;
     })
     .then(function () {
-        return Q.nfcall(execFile, 'git', ['status', '--porcelain'], {env: process.env});
+        return git(['status', '--porcelain']);
     })
     .then(function (value) {
         var stdout = value[0];
@@ -111,12 +122,12 @@ function filterModifiedStatusLines(stdout) {
 function gitCommitAndTag(newVersion, message) {
     message = message || 'v' + newVersion;
     message = message.replace(/%s/g, newVersion);
-    return Q.nfcall(execFile, 'git', ['add', 'bower.json'], {env: process.env})
+    return git(['add', 'bower.json'])
     .then(function () {
-        return Q.nfcall(execFile, 'git', ['commit', '-m', message], {env: process.env});
+        return git(['commit', '-m', message]);
     })
     .then(function () {
-        return Q.nfcall(execFile, 'git', ['tag', newVersion, '-am', message], {env: process.env});
+        return git(['tag', newVersion, '-am', message]);
     });
 }
 

--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -9,6 +9,7 @@ var PackageRepository = require('./PackageRepository');
 var semver = require('../util/semver');
 var copy = require('../util/copy');
 var createError = require('../util/createError');
+var findRoot = require('../util/findRoot');
 var scripts = require('./scripts');
 
 function Manager(config, logger) {
@@ -118,12 +119,12 @@ Manager.prototype.install = function (json) {
         return Q.reject(createError('Already working', 'EWORKING'));
     }
 
-    // If nothing to install, skip the code bellow
+    // If nothing to install, skip the code below
     if (mout.lang.isEmpty(that._dissected)) {
         return Q.resolve({});
     }
 
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = path.join(this.getRootDir(), this._config.directory);
     return Q.nfcall(mkdirp, componentsDir)
     .then(function () {
         return scripts.preinstall(that._config, that._logger, that._dissected, that._installed, json);
@@ -248,6 +249,13 @@ Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps) {
 
 Manager.prototype.getPackageRepository = function () {
     return this._repository;
+};
+
+Manager.prototype.getRootDir = function () {
+    if (!this._rootDir) {
+        this._rootDir = findRoot(this._config.cwd);
+    }
+    return this._rootDir;
 };
 
 // -----------------
@@ -553,7 +561,7 @@ Manager.prototype._dissect = function () {
         }, this);
 
         // Filter only packages that need to be installed
-        componentsDir = path.resolve(that._config.cwd, that._config.directory);
+        componentsDir = path.resolve(this.getRootDir(), that._config.directory);
         this._dissected = mout.object.filter(suitables, function (decEndpoint, name) {
             var installedMeta = this._installed[name];
             var dst;

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -9,6 +9,7 @@ var Logger = require('bower-logger');
 var Manager = require('./Manager');
 var defaultConfig = require('../config');
 var semver = require('../util/semver');
+var findRoot = require('../util/findRoot');
 var md5 = require('../util/md5');
 var createError = require('../util/createError');
 var readJson = require('../util/readJson');
@@ -402,7 +403,7 @@ Project.prototype.saveJson = function (forceCreate) {
         return Q.resolve();
     }
 
-    file = this._jsonFile || path.join(this._config.cwd, 'bower.json');
+    file = this._jsonFile || path.join(this.getRootDir(), 'bower.json');
     return Q.nfcall(fs.writeFile, file, jsonStr)
     .then(function () {
         this._jsonHash = jsonHash;
@@ -430,6 +431,13 @@ Project.prototype.getPackageRepository = function () {
     return this._manager.getPackageRepository();
 };
 
+Project.prototype.getRootDir = function () {
+    if (!this._rootDir) {
+        this._rootDir = findRoot(this._config.cwd);
+    }
+    return this._rootDir;
+};
+
 // -----------------
 
 Project.prototype._analyse = function () {
@@ -444,10 +452,10 @@ Project.prototype._analyse = function () {
 
         root = {
             name: json.name,
-            source: this._config.cwd,
+            source: this.getRootDir(),
             target: json.version || '*',
             pkgMeta: jsonCopy,
-            canonicalDir: this._config.cwd,
+            canonicalDir: this.getRootDir(),
             root: true
         };
 
@@ -534,8 +542,8 @@ Project.prototype._readJson = function () {
     }
 
     // Read local json
-    return this._json = readJson(this._config.cwd, {
-        assume: { name: path.basename(this._config.cwd) || 'root' }
+    return this._json = readJson(this.getRootDir(), {
+        assume: { name: path.basename(this.getRootDir()) || 'root' }
     })
     .spread(function (json, deprecated, assumed) {
         var jsonStr;
@@ -545,7 +553,7 @@ Project.prototype._readJson = function () {
         }
 
         if (!assumed) {
-            that._jsonFile = path.join(that._config.cwd, deprecated ? deprecated : 'bower.json');
+            that._jsonFile = path.join(that.getRootDir(), deprecated ? deprecated : 'bower.json');
         }
 
         jsonStr = JSON.stringify(json, null, '  ') + '\n';
@@ -564,7 +572,7 @@ Project.prototype._readInstalled = function () {
 
     // Gather all folders that are actual packages by
     // looking for the package metadata file
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = path.join(this.getRootDir(), this._config.directory);
     return this._installed = Q.nfcall(glob, '*/.bower.json', {
         cwd: componentsDir,
         dot: true
@@ -605,7 +613,7 @@ Project.prototype._readLinks = function () {
     var that = this;
 
     // Read directory, looking for links
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = path.join(this.getRootDir(), this._config.directory);
     return Q.nfcall(fs.readdir, componentsDir)
     .then(function (filenames) {
         var promises;

--- a/lib/util/findRoot.js
+++ b/lib/util/findRoot.js
@@ -1,0 +1,28 @@
+var fs = require('graceful-fs');
+var path = require('path');
+
+function findRoot(cwd) {
+    var root = null;
+
+    if (!cwd) {
+        // If no path is passed in, default to CWD
+        cwd = process.cwd();
+    }
+
+    var current = cwd;
+
+    while (current !== '/') {
+        if (fs.existsSync(path.join(current, 'bower.json')) && !fs.existsSync(path.join(current, '.bower.json'))) {
+            root = current;
+        }
+        current = path.dirname(current);
+    }
+
+    if (root === null) {
+        root = cwd;
+    }
+
+    return root;
+}
+
+module.exports = findRoot;


### PR DESCRIPTION
**DO NOT MERGE** This PR changes the way that Bower works, so should be considered a v2.0 feature.

With this PR, Bower will now look for the root of the current project, and use that as the working directory for most other actions. The project root is the first path we find that has a `bower.json` that does NOT also have a `.bower.json`. `.bower.json` files mark installed dependencies. The search order is from the CWD upwards.

If no suitable project root is found, use the CWD as normal.

Please discuss/test.
