### PR TITLE
Use master branch as default Git target

### DIFF
--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -94,7 +94,7 @@ GitResolver.prototype._findResolution = function (target) {
     var self = this.constructor;
     var that = this;
 
-    target = target || this._target || '*';
+    target = target || this._target || '#master';
 
     // Target is a commit, so it's a stale target (not a moving target)
     // There's nothing to do in this case


### PR DESCRIPTION
When specifying a Git URL as dependency like `"dependency": "git@github.com:user/repository.git"` Bower will resolve it as `git@github.com:user/repository.git#*`.

The addition of `#*` will make Bower fetch the latest tag. So if new commits have been made since the latest tag, these will be ignored by Bower. While I'd expect that referencing just the repository without a specific target would result in fetching the latest version of that repository.

The `package.json` configuration of NPM works like this as well. As specified on https://www.npmjs.org/doc/json.html#Git-URLs-as-Dependencies, omitting the target will default to `#master`.

Therefore I created this Pull Requests that changes the default target for Git from `#*` to `#master`.
