### PR TITLE
Limit the number of parallel SSH connections (– to fix #1256)

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -7,6 +7,8 @@ var GitResolver = require('./GitResolver');
 var cmd = require('../../util/cmd');
 
 function GitRemoteResolver(decEndpoint, config, logger) {
+    var parsedUrl;
+
     GitResolver.call(this, decEndpoint, config, logger);
 
     if (!mout.string.startsWith(this._source, 'file://')) {
@@ -21,10 +23,14 @@ function GitRemoteResolver(decEndpoint, config, logger) {
 
     // Get the host of this source
     if (!/:\/\//.test(this._source)) {
-        this._host = url.parse('ssh://' + this._source).host;
+        parsedUrl = url.parse('ssh://' + this._source);
     } else {
-        this._host = url.parse(this._source).host;
+        parsedUrl = url.parse(this._source);
     }
+    this._host = parsedUrl.host;
+
+    // Remember the protocol, sans the trailing colon, for throttling
+    this._protocol = parsedUrl.protocol.substr(0, parsedUrl.protocol.length-1);
 }
 
 util.inherits(GitRemoteResolver, GitResolver);
@@ -100,8 +106,8 @@ GitRemoteResolver.prototype._findResolution = function (target) {
 // ------------------------------
 
 GitRemoteResolver.prototype._slowClone = function (resolution) {
-    return cmd('git', ['clone', this._source, this._tempDir, '--progress'])
-    .then(cmd.bind(cmd, 'git', ['checkout', resolution.commit], { cwd: this._tempDir }));
+    return cmd('git', ['clone', this._source, this._tempDir, '--progress'], { type: this._protocol })
+    .then(cmd.bind(cmd, 'git', ['checkout', resolution.commit], { cwd: this._tempDir, type: this._protocol }));
 };
 
 GitRemoteResolver.prototype._fastClone = function (resolution) {
@@ -117,7 +123,7 @@ GitRemoteResolver.prototype._fastClone = function (resolution) {
         args.push('--depth', 1);
     }
 
-    return cmd('git', args, { cwd: this._tempDir })
+    return cmd('git', args, { cwd: this._tempDir, type: this._protocol })
     .spread(function (stdout, stderr) {
         // Only after 1.7.10 --branch accepts tags
         // Detect those cases and inform the user to update git otherwise it's
@@ -170,7 +176,7 @@ GitRemoteResolver.refs = function (source) {
     }
 
     // Store the promise in the refs object
-    value = cmd('git', ['ls-remote', '--tags', '--heads', source])
+    value = cmd('git', ['ls-remote', '--tags', '--heads', source], { type: this._protocol })
     .spread(function (stdout) {
         var refs;
 

--- a/lib/util/cmd.js
+++ b/lib/util/cmd.js
@@ -10,7 +10,11 @@ var createError = require('./createError');
 // having a large number of commands spawned at once, so it isn't super
 // important for this number to be large. However, it would still be nice to
 // *know* how high this number can be, rather than having to guess low.
-var throttler = new PThrottler(50);
+// Also, we need to throttle SSH (many servers are set up to not handle more
+// than 10 sessions).
+var throttler = new PThrottler(50, {
+    ssh: 5
+});
 
 var winBatchExtensions;
 var winWhichCache;
@@ -111,7 +115,11 @@ function executeCmd(command, args, options) {
 }
 
 function cmd(command, args, options) {
-    return throttler.enqueue(executeCmd.bind(null, command, args, options));
+    var type;
+    if (options) {
+        type = options.type;
+    }
+    return throttler.enqueue(executeCmd.bind(null, command, args, options), type);
 }
 
 module.exports = cmd;


### PR DESCRIPTION
See #1256 for the bug description.

I used `p-throttler` to limit the number of parallel Git commands based on the protocol.
Why 5 instances? I first tried 10, but that didn't work – I guess the server did not close the connections fast enough…
