### PR TITLE
Mirror `npm version` format for git tags

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -109,14 +109,15 @@ function filterModifiedStatusLines(stdout) {
 }
 
 function gitCommitAndTag(newVersion, message) {
-    message = message || 'v' + newVersion;
+    var tag = 'v' + newVersion;
+    message = message || tag;
     message = message.replace(/%s/g, newVersion);
     return Q.nfcall(execFile, 'git', ['add', 'bower.json'], {env: process.env})
     .then(function () {
         return Q.nfcall(execFile, 'git', ['commit', '-m', message], {env: process.env});
     })
     .then(function () {
-        return Q.nfcall(execFile, 'git', ['tag', newVersion, '-am', message], {env: process.env});
+        return Q.nfcall(execFile, 'git', ['tag', tag, '-am', message], {env: process.env});
     });
 }
 


### PR DESCRIPTION
See https://github.com/bower/bower/pull/961#issuecomment-33981712 and  https://github.com/bower/bower/pull/961#issuecomment-35591108 for more context.
