### PR TITLE
Improve CLI output for conflicts

### DIFF
--- a/templates/std/conflict-resolved.std
+++ b/templates/std/conflict-resolved.std
@@ -1,9 +1,9 @@
 {{#yellow}}Please note that,{{/yellow}}
 {{#condense}}
 {{#each picks}}
-    {{#if dependants}}{{#white}}{{dependants}}{{/white}}{{else}}none{{/if}} depends on {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#white}}{{endpoint.name}}#{{pkgMeta._release}}{{/white}}{{/if}}
+    {{#if dependants}}{{#green}}{{dependants}}{{/green}}{{else}}none{{/if}} depends on {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#green}}{{endpoint.name}}#{{pkgMeta._release}}{{/green}}{{/if}}
 {{/each}}
 {{/condense}}
 
-Resort to using {{#cyan}}{{suitable.endpoint.name}}#{{resolution}}{{/cyan}} which resolved to {{#white}}{{suitable.endpoint.name}}#{{suitable.pkgMeta._release}}{{/white}}
+Resort to using {{#cyan}}{{suitable.endpoint.name}}#{{resolution}}{{/cyan}} which resolved to {{#green}}{{suitable.endpoint.name}}#{{suitable.pkgMeta._release}}{{/green}}
 Code incompatibilities may occur.

--- a/templates/std/conflict.std
+++ b/templates/std/conflict.std
@@ -1,7 +1,7 @@
 {{#yellow}}Unable to find a suitable version for {{name}}, please choose one:{{/yellow}}
 {{#condense}}
 {{#each picks}}
-    {{#magenta}}{{sum @index 1}}){{/magenta}} {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#white}}{{pkgMeta._release}}{{/white}}{{/if}}{{#if dependants}} and is required by {{#white}}{{dependants}}{{/white}} {{/if}}
+    {{#magenta}}{{sum @index 1}}){{/magenta}} {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#green}}{{pkgMeta._release}}{{/green}}{{/if}}{{#if dependants}} and is required by {{#green}}{{dependants}}{{/green}} {{/if}}
 {{/each}}
 {{/condense}}
 {{#unless saveResolutions}}


### PR DESCRIPTION
When using light theme for CLI interface, white color can’t be easily distinguished. This PR replaces white text color with the green one which will easily work with both types of themes.

Before:
![screen shot 2014-05-07 at 19 35 46](https://cloud.githubusercontent.com/assets/389286/2906228/54c21e2e-d60e-11e3-8ff2-f197f9fbae8b.png)

After:
![screen shot 2014-05-07 at 19 36 01](https://cloud.githubusercontent.com/assets/389286/2906229/588c7950-d60e-11e3-8f41-26d53f68906b.png)
