### PR TITLE
Fix Git over SSH concurrency issue (ECMDERR with exit code 128)

### DIFF
--- a/lib/util/cmd.js
+++ b/lib/util/cmd.js
@@ -10,7 +10,7 @@ var createError = require('./createError');
 // having a large number of commands spawned at once, so it isn't super
 // important for this number to be large. However, it would still be nice to
 // *know* how high this number can be, rather than having to guess low.
-var throttler = new PThrottler(50);
+var throttler = new PThrottler(8);
 
 var winBatchExtensions;
 var winWhichCache;


### PR DESCRIPTION
The default max concurrent SSH connections limit with on many servers in 10 (see MaxSession in http://www.manpagez.com/man/5/sshd_config/). With a current throttling limit of 50, bower (Git) has a tendency to quickly run out of connection return exit with a "ECMDERR with exit code 128". The only proposed solution as of now was to use HTTPS instead of SSH to work around the limit (see issue #32 or #50, #689, #1245, #713, #376), something working with GitHub but not possible on my current configuration (private repos). Another commonly proposed solution is also to clean Bower's cache, which changes to concurrency order and sometimes work, but not when 15 repos are hosted on the same server. Limiting the currency level of the command runner fixes the issue, without any perceivable speed impact.
