### PR TITLE
Resolve a situation in which the install process gets into an infinite loop

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -55,7 +55,7 @@ Project.prototype.install = function (decEndpoints, options) {
             } else {
                 resolved[name] = node;
             }
-        });
+        }, true);
 
         // Add decomposed endpoints as targets
         decEndpoints = decEndpoints || [];


### PR DESCRIPTION
As reported by @ajklein in IRC, sometimes Bower will just hang when trying to install. In this case it was because of a dependency loop, e.g. A depends on B depends on A, etc. We already had a way to handle this situation so I just turned it on.
