### PR TITLE
Add private flag to init command

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -12,7 +12,7 @@ var cli = require('../util/cli');
 var cmd = require('../util/cmd');
 var createError = require('../util/createError');
 
-function init(config) {
+function init(options, config) {
     var project;
     var logger = new Logger();
 
@@ -35,7 +35,7 @@ function init(config) {
     // Fill in defaults
     .then(setDefaults.bind(null, config))
     // Now prompt user to make changes
-    .then(promptUser.bind(null, logger))
+    .then(promptUser.bind(null, options, logger))
     // Set ignore based on the response
     .spread(setIgnore.bind(null, config))
     // Set dependencies based on the response
@@ -175,81 +175,78 @@ function setDefaults(config, json) {
     });
 }
 
-function promptUser(logger, json) {
-    var questions = [
-        {
-            'name': 'name',
-            'message': 'name',
-            'default': json.name,
-            'type': 'input'
-        },
-        {
-            'name': 'version',
-            'message': 'version',
-            'default': json.version,
-            'type': 'input'
-        },
-        {
-            'name': 'description',
-            'message': 'description',
-            'default': json.description,
-            'type': 'input'
-        },
-        {
-            'name': 'main',
-            'message': 'main file',
-            'default': json.main,
-            'type': 'input'
-        },
-        {
-            'name': 'moduleType',
-            'message': 'what types of modules does this package expose?',
-            'type': 'checkbox',
-            'choices': ['amd', 'es6', 'globals', 'node', 'yui']
-        },
-        {
-            'name': 'keywords',
-            'message': 'keywords',
-            'default': json.keywords ? json.keywords.toString() : null,
-            'type': 'input'
-        },
-        {
-            'name': 'authors',
-            'message': 'authors',
-            'default': json.authors ? json.authors.toString() : null,
-            'type': 'input'
-        },
-        {
-            'name': 'license',
-            'message': 'license',
-            'default': json.license || 'MIT',
-            'type': 'input'
-        },
-        {
-            'name': 'homepage',
-            'message': 'homepage',
-            'default': json.homepage,
-            'type': 'input'
-        },
-        {
-            'name': 'dependencies',
-            'message': 'set currently installed components as dependencies?',
-            'default': !mout.object.size(json.dependencies) && !mout.object.size(json.devDependencies),
-            'type': 'confirm'
-        },
-        {
-            'name': 'ignore',
-            'message': 'add commonly ignored files to ignore list?',
-            'default': true,
-            'type': 'confirm'
-        },
-        {
-            'name': 'private',
-            'message': 'would you like to mark this package as private which prevents it from being accidentally published to the registry?',
-            'default': !!json.private,
-            'type': 'confirm'
-        }
-    ];
+function promptUser(options, logger, json) {
+    var questions = [{
+        'name': 'name',
+        'message': 'name',
+        'default': json.name,
+        'type': 'input'
+    }];
+
+    if (!options.private) {
+        questions.push.apply(questions, [
+            {
+                'name': 'version',
+                'message': 'version',
+                'default': json.version,
+                'type': 'input'
+            },
+            {
+                'name': 'description',
+                'message': 'description',
+                'default': json.description,
+                'type': 'input'
+            },
+            {
+                'name': 'main',
+                'message': 'main file',
+                'default': json.main,
+                'type': 'input'
+            },
+            {
+                'name': 'moduleType',
+                'message': 'what types of modules does this package expose?',
+                'type': 'checkbox',
+                'choices': ['amd', 'es6', 'globals', 'node', 'yui']
+            },
+            {
+                'name': 'keywords',
+                'message': 'keywords',
+                'default': json.keywords ? json.keywords.toString() : null,
+                'type': 'input'
+            },
+            {
+                'name': 'authors',
+                'message': 'authors',
+                'default': json.authors ? json.authors.toString() : null,
+                'type': 'input'
+            },
+            {
+                'name': 'license',
+                'message': 'license',
+                'default': json.license || 'MIT',
+                'type': 'input'
+            },
+            {
+                'name': 'homepage',
+                'message': 'homepage',
+                'default': json.homepage,
+                'type': 'input'
+            },
+            {
+                'name': 'dependencies',
+                'message': 'set currently installed components as dependencies?',
+                'default': !mout.object.size(json.dependencies) && !mout.object.size(json.devDependencies),
+                'type': 'confirm'
+            },
+            {
+                'name': 'ignore',
+                'message': 'add commonly ignored files to ignore list?',
+                'default': true,
+                'type': 'confirm'
+            }
+        ]);
+    }
 
     return Q.nfcall(logger.prompt.bind(logger), questions)
     .then(function (answers) {
@@ -262,14 +259,14 @@ function promptUser(logger, json) {
         json.authors = toArray(answers.authors, ',');
         json.license = answers.license;
         json.homepage = answers.homepage;
-        json.private = answers.private || null;
+        json.private = options.private || null;
 
         return [json, answers];
     });
 }
 
 function toArray(value, splitter) {
-    var arr = value.split(splitter || /[\s,]/);
+    var arr = (value || '').split(splitter || /[\s,]/);
 
     // Trim values
     arr = arr.map(function (item) {
@@ -329,12 +326,14 @@ function setDependencies(project, json, answers) {
 
 // -------------------
 
-init.line = function () {
-    return init();
+init.line = function (argv) {
+    return init(init.options(argv));
 };
 
 init.options = function (argv) {
-    return cli.readOptions(argv);
+    return cli.readOptions({
+        'private': { type: Boolean, shorthand: 'p' }
+    }, argv);
 };
 
 init.completion = function () {


### PR DESCRIPTION
Running `bower init --private` will skip over all prompts but name (that is, all but what is *required*). I've also removed the private prompt as it would now be a bit repetitive. Rerunning the command without the flag will remove the private property.

Link to issue #1304.