### PR TITLE
Search compatible versions in fetching packages

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -795,6 +795,10 @@ Manager.prototype._areCompatible = function (candidate, resolved) {
     var resolvedVersion;
     var highestCandidate;
     var highestResolved;
+    var candidateIsRange = semver.validRange(candidate.target);
+    var resolvedIsRange = semver.validRange(resolved.target);
+    var candidateIsVersion = semver.valid(candidate.target);
+    var resolvedIsVersion = semver.valid(resolved.target);
 
     // Check if targets are equal
     if (candidate.target === resolved.target) {
@@ -802,25 +806,46 @@ Manager.prototype._areCompatible = function (candidate, resolved) {
     }
 
     resolvedVersion = resolved.pkgMeta && resolved.pkgMeta.version;
+    // If there is no pkgMeta, resolvedVersion is downloading now
+    // Check based on target requirements
     if (!resolvedVersion) {
+        // If one of the targets is range and other is version,
+        // check version against the range
+        if (candidateIsVersion && resolvedIsRange) {
+            return semver.satisfies(candidate.target, resolved.target);
+        }
+
+        if (resolvedIsVersion && candidateIsRange) {
+            return semver.satisfies(resolved.target, candidate.target);
+        }
+
+        if (resolvedIsVersion && candidateIsVersion) {
+            return semver.eq(resolved.target, candidate.target);
+        }
+
+        // If both targets are range, check that both have same
+        // higher cap
+        if (resolvedIsRange && candidateIsRange) {
+            highestCandidate = this._getCap(semver.toComparators(candidate.target), 'highest');
+            highestResolved = this._getCap(semver.toComparators(resolved.target), 'highest');
+            if (!highestResolved.version || !highestCandidate.version) {
+                return;
+            }
+
+            return semver.eq(highestCandidate.version, highestResolved.version) &&
+                highestCandidate.comparator === highestResolved.comparator;
+        }
         return false;
     }
 
     // If target is a version, compare against the resolved version
-    if (semver.valid(candidate.target)) {
+    if (candidateIsVersion) {
         return semver.eq(candidate.target, resolvedVersion);
     }
 
-    // If target is a range, check if the max versions of the range are the same
-    // and if the resolved version satisfies the candidate target
-    if (semver.validRange(candidate.target) && semver.validRange(resolved.target)) {
-        highestCandidate = this._getCap(semver.toComparators(candidate.target), 'highest');
-        highestResolved = this._getCap(semver.toComparators(resolved.target), 'highest');
-
-        return highestCandidate.version && highestResolved.version &&
-               semver.eq(highestCandidate.version, highestResolved.version) &&
-               highestCandidate.comparator === highestResolved.comparator &&
-               semver.satisfies(resolvedVersion, candidate.target);
+    // If target is a range, check if resolved version satisfies it
+    if (candidateIsRange) {
+        return semver.satisfies(resolvedVersion, candidate.target);
     }
 
     return false;


### PR DESCRIPTION
Previous version of code reported endpoints that does not have pkgMeta
(not downloaded) yet and does not have exactly equal targets as
incompatible. This caused some package to be downloaded multiple times
and caused conflict errors (#1147).

This patch adds proper code for searching compatible version in
currently fetching packages basing on targets.

It also simplifies check for case when we have resolvedVersion and
candidate's target is range.
