### PR TITLE
Updated Analytics section of readme.md with link to stats.bower.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ $ bower completion >> ~/.bash_profile
 
 ## Analytics
 
-Bower can collect anonymous usage statistics. This allows the community to improve Bower and publically display insights into CLI usage and Bower's packages at [stats.bower.io](http://stats.bower.io).
+Bower can collect anonymous usage statistics. This allows the community to improve Bower and publicly display insights into CLI usage and packages at [stats.bower.io](http://stats.bower.io).
 
-Data is tracked using Google Analytics and instrumented via [Yeoman Insight](https://github.com/yeoman/insight). It is made available to all bower team members. Tracking is opt-in upon initial usage. If you'd prefer to disable analytics altogether, you can manually opt-out, or create either a local, or global `.bowerrc` file with below flag:
+Data is tracked using Google Analytics and instrumented via [Insight](https://github.com/yeoman/insight). It is made available to all bower team members. Tracking is opt-in upon initial usage. If you'd prefer to disable analytics altogether, you can manually opt-out, or create either a local, or global `.bowerrc` file with below flag:
 
 ```json
 {


### PR DESCRIPTION
Minor changes and added link to newly launched http://stats.bower.io per work here: https://github.com/bower/bower/issues/1164
