### PR TITLE
Fix callstack error when processing installed packages with circular deps. Fixes #1349

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -728,7 +728,7 @@ Project.prototype._removePackages = function (packages) {
     });
 };
 
-Project.prototype._restoreNode = function (node, flattened, jsonKey) {
+Project.prototype._restoreNode = function (node, flattened, jsonKey, processed) {
     var deps;
 
     // Do not restore if the node is missing
@@ -738,10 +738,11 @@ Project.prototype._restoreNode = function (node, flattened, jsonKey) {
 
     node.dependencies = node.dependencies || {};
     node.dependants = node.dependants || {};
+    processed = processed || {};
 
     // Only process deps that are not yet processed
     deps = mout.object.filter(node.pkgMeta[jsonKey], function (value, key) {
-        return !node.dependencies[key];
+        return !processed[node.name + ':' + key];
     });
 
     mout.object.forOwn(deps, function (value, key) {
@@ -788,15 +789,16 @@ Project.prototype._restoreNode = function (node, flattened, jsonKey) {
 
         // Cross reference
         node.dependencies[key] = restored;
+        processed[node.name + ':' + key] = true;
+
         restored.dependants = restored.dependants || {};
         restored.dependants[node.name] = mout.object.mixIn({}, node);  // We need to clone due to shared objects in the manager!
 
         // Call restore for this dependency
-        this._restoreNode(restored, flattened, 'dependencies');
-
+        this._restoreNode(restored, flattened, 'dependencies', processed);
         // Do the same for the incompatible local package
         if (local && restored !== local) {
-            this._restoreNode(local, flattened, 'dependencies');
+            this._restoreNode(local, flattened, 'dependencies', processed);
         }
     }, this);
 };


### PR DESCRIPTION
To reproduce the bug:
1. Install a package the dependencies of which have circular dependencies. This should complete with no errors.
2. Run the same command again: CALLSTACK EXCEEDED error will occur.

Bower falls into recursion while analysing installed packages.
