### PR TITLE
Components that are not installed by bower should be left alone

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -11,6 +11,18 @@ var copy = require('../util/copy');
 var createError = require('../util/createError');
 var scripts = require('./scripts');
 
+// We need to manually wrap the exists function because, unlike every other
+// node method, the callback does not have error as the first parameter.
+var pathExists = function (path) {
+    var deferred = Q.defer();
+
+    fs.exists(path, function (exists) {
+        deferred.resolve(exists);
+    });
+
+    return deferred.promise;
+};
+
 function Manager(config, logger) {
     this._config = config;
     this._logger = logger;
@@ -118,7 +130,7 @@ Manager.prototype.install = function (json) {
         return Q.reject(createError('Already working', 'EWORKING'));
     }
 
-    // If nothing to install, skip the code bellow
+    // If nothing to install, skip the code below
     if (mout.lang.isEmpty(that._dissected)) {
         return Q.resolve({});
     }
@@ -132,7 +144,6 @@ Manager.prototype.install = function (json) {
         var promises = [];
 
         mout.object.forOwn(that._dissected, function (decEndpoint, name) {
-            var promise;
             var dst;
             var release = decEndpoint.pkgMeta._release;
 
@@ -140,31 +151,43 @@ Manager.prototype.install = function (json) {
 
             dst = path.join(componentsDir, name);
 
-            // Remove existent and copy canonical dir
-            promise = Q.nfcall(rimraf, dst)
-            .then(copy.copyDir.bind(copy, decEndpoint.canonicalDir, dst))
-            .then(function () {
-                var metaFile = path.join(dst, '.bower.json');
+            pathExists(dst)
+            .then(function (exists) {
+                var promise;
 
-                decEndpoint.canonicalDir = dst;
+                if (exists && !that._installed[name] && !that._config.force) {
+                    // There is a folder in the components directory that has
+                    // this name, but it was not installed by bower.
+                    that._logger.warn('skipped', name + ' was not installed because there is already a non-bower directory with that name in the components directory (' + path.relative(that._config.cwd, dst) + '). You can force installation with --force.');
+                    return;
+                }
 
-                // Store additional metadata in bower.json
-                return Q.nfcall(fs.readFile, metaFile)
-                .then(function (contents) {
-                    var json = JSON.parse(contents.toString());
+                // Remove existent and copy canonical dir
+                promise = Q.nfcall(rimraf, dst)
+                .then(copy.copyDir.bind(copy, decEndpoint.canonicalDir, dst))
+                .then(function () {
+                    var metaFile = path.join(dst, '.bower.json');
 
-                    json._target = decEndpoint.target;
-                    json._originalSource = decEndpoint.source;
-                    if (decEndpoint.newly) {
-                        json._direct = true;
-                    }
+                    decEndpoint.canonicalDir = dst;
 
-                    json = JSON.stringify(json, null, '  ');
-                    return Q.nfcall(fs.writeFile, metaFile, json);
+                    // Store additional metadata in bower.json
+                    return Q.nfcall(fs.readFile, metaFile)
+                    .then(function (contents) {
+                        var json = JSON.parse(contents.toString());
+
+                        json._target = decEndpoint.target;
+                        json._originalSource = decEndpoint.source;
+                        if (decEndpoint.newly) {
+                            json._direct = true;
+                        }
+
+                        json = JSON.stringify(json, null, '  ');
+                        return Q.nfcall(fs.writeFile, metaFile, json);
+                    });
                 });
-            });
 
-            promises.push(promise);
+                promises.push(promise);
+            });
         });
 
         return Q.all(promises);


### PR DESCRIPTION
Some people want to be able to mix local versions of components with ones bower installs, e.g. putting a modified version of jquery into b_c. If you do this and have components that depend on jquery then every time you `bower install` or `bower update`, your custom version will be deleted and overwritten with the regular version.

While I know this is not a common case, it is very frustrating for people who try it and we don't *need* to make it impossible.