### PR TITLE
[#931] Make --force always re-run installation

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -25,7 +25,7 @@ function install(logger, endpoints, options, config) {
     });
     tracker.trackDecomposedEndpoints('install', decEndpoints);
 
-    return project.install(decEndpoints, options);
+    return project.install(decEndpoints, options, config);
 }
 
 // -------------------

--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -558,12 +558,8 @@ Manager.prototype._dissect = function () {
             var installedMeta = this._installed[name];
             var dst;
 
-            // Analyse a few props
-            if (installedMeta &&
-                installedMeta._target === decEndpoint.target &&
-                installedMeta._originalSource === decEndpoint.source &&
-                installedMeta._release === decEndpoint.pkgMeta._release
-            ) {
+            // Skip linked dependencies
+            if (decEndpoint.linked) {
                 return false;
             }
 
@@ -571,6 +567,15 @@ Manager.prototype._dissect = function () {
             dst = path.join(componentsDir, name);
             if (dst === decEndpoint.canonicalDir) {
                 return false;
+            }
+
+            // Analyse a few props
+            if (installedMeta &&
+                installedMeta._target === decEndpoint.target &&
+                installedMeta._originalSource === decEndpoint.source &&
+                installedMeta._release === decEndpoint.pkgMeta._release
+            ) {
+                return this._config.force;
             }
 
             return true;

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -29,7 +29,7 @@ function Project(config, logger) {
 
 // -----------------
 
-Project.prototype.install = function (decEndpoints, options) {
+Project.prototype.install = function (decEndpoints, options, config) {
     var that = this;
     var targets = [];
     var resolved = {};
@@ -41,6 +41,7 @@ Project.prototype.install = function (decEndpoints, options) {
     }
 
     this._options = options || {};
+    this._config = config || {};
     this._working = true;
 
     // Analyse the project
@@ -48,10 +49,10 @@ Project.prototype.install = function (decEndpoints, options) {
     .spread(function (json, tree) {
         // Recover tree
         that.walkTree(tree, function (node, name) {
-            if (node.missing || node.different) {
-                targets.push(node);
-            } else if (node.incompatible) {
+            if (node.incompatible) {
                 incompatibles.push(node);
+            } else if (node.missing || node.different || that._config.force) {
+                targets.push(node);
             } else {
                 resolved[name] = node;
             }


### PR DESCRIPTION
1. Mark component as "target to be resolved" not only if missing or different, but also if --force is set
2. Make sure linked component are not marked "target to be resolved" even if --force is set

Should fix #931, among others.
