### PR TITLE
[#1356] Disable caching for local resources

### DIFF
--- a/lib/core/PackageRepository.js
+++ b/lib/core/PackageRepository.js
@@ -46,7 +46,11 @@ PackageRepository.prototype.fetch = function (decEndpoint) {
         info.resolver = resolver;
         isTargetable = resolver.constructor.isTargetable;
 
-        // If force flag is used, bypass cache
+        if (resolver.isNotCacheable()) {
+            return that._resolve(resolver, logger);
+        }
+
+        // If force flag is used, bypass cache, but write to cache anyway
         if (that._config.force) {
             logger.action('resolve', resolver.getSource() + '#' + resolver.getTarget());
             return that._resolve(resolver, logger);
@@ -171,12 +175,11 @@ PackageRepository.prototype._resolve = function (resolver, logger) {
     return resolver.resolve()
     // Store in the cache
     .then(function (canonicalDir) {
-        // We don't want to cache moving targets like branches
-        if (resolver._resolution && resolver._resolution.type === 'branch') {
+        if (resolver.isNotCacheable()) {
             return canonicalDir;
-        } else {
-            return that._resolveCache.store(canonicalDir, resolver.getPkgMeta());
         }
+
+        return that._resolveCache.store(canonicalDir, resolver.getPkgMeta());
     })
     // Resolve promise with canonical dir and package meta
     .then(function (dir) {

--- a/lib/core/resolvers/Resolver.js
+++ b/lib/core/resolvers/Resolver.js
@@ -114,6 +114,26 @@ Resolver.prototype.resolve = function () {
     });
 };
 
+Resolver.prototype.isNotCacheable = function () {
+    // Bypass cache for local dependencies
+    if (this._source &&
+        /^(?:file:[\/\\]{2})?\.?\.?[\/\\]/.test(this._source)
+    ) {
+        return true;
+    }
+
+    // We don't want to cache moving targets like branches
+    if (this._pkgMeta &&
+        this._pkgMeta._resolution &&
+        this._pkgMeta._resolution.type === 'branch')
+    {
+        return true;
+    }
+
+    return false;
+};
+
+
 // -----------------
 
 // Abstract functions that must be implemented by concrete resolvers


### PR DESCRIPTION
1. Discover if component is not cacheable (either local resource or branch), and skip caching
2. Add new test and force existing tests to use cache, even they use local resources

Should fix #1356, among others.
