### PR TITLE
Auto-sort bower.json dependencies alphabetically, fixes #1373

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -14,6 +14,7 @@ var createError = require('../util/createError');
 var readJson = require('../util/readJson');
 var validLink = require('../util/validLink');
 var scripts = require('./scripts');
+var sortobject = require('deep-sort-object');
 
 function Project(config, logger) {
     // This is the only architecture component that ensures defaults
@@ -98,11 +99,11 @@ Project.prototype.install = function (decEndpoints, options, config) {
                 }
 
                 if (that._options.save) {
-                    that._json.dependencies = mout.object.mixIn(that._json.dependencies || {}, jsonEndpoint);
+                    that._json.dependencies = sortobject(mout.object.mixIn(that._json.dependencies || {}, jsonEndpoint));
                 }
 
                 if (that._options.saveDev) {
-                    that._json.devDependencies = mout.object.mixIn(that._json.devDependencies || {}, jsonEndpoint);
+                    that._json.devDependencies = sortobject(mout.object.mixIn(that._json.devDependencies || {}, jsonEndpoint));
                 }
             });
         }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chalk": "^1.0.0",
     "chmodr": "0.1.0",
     "decompress-zip": "^0.1.0",
+    "deep-sort-object": "~0.1.1",
     "fstream": "^1.0.3",
     "fstream-ignore": "^1.0.2",
     "glob": "^4.3.2",


### PR DESCRIPTION
This patch fixed #1373.

> I like how, as of late, npm install --save automatically re-writes package.json so that dependencies are listed in alphabetical order. Makes it easier to visually parse the file, and ensures some consistency across different Node.js projects. That said, I'm sure some folks prefer to have dependencies listed in order of when they were saved, but that's what version control (e.g. git blame) is for IMO.
> 
> Would be nice to have this feature when doing bower install --save. Thoughts?
