### PR TITLE
It should shows an error when `bower install` failed, fixes #922

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -49,7 +49,7 @@ Project.prototype.install = function (decEndpoints, options, config) {
     .spread(function (json, tree) {
         //It should shows an error when `bower install` failed reason no bower.json in current directory
         if(!that._jsonFile && decEndpoints.length === 0 ) {
-            throw createError('bower can\'t find a bower.json file in your current directory', 'ENOENT');
+            throw createError('No bower.json present', 'ENOENT');
         }
         
         // Recover tree

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -19,12 +19,6 @@ describe('bower install', function () {
         interactive: true
     };
 
-    it('does nothing if no bower.json is present', function () {
-        var logger = bower.commands.install([], undefined, config);
-
-        return helpers.expectEvent(logger, 'end');
-    });
-
     it.skip('installs a package', function () {
         this.timeout(10000);
         var logger = bower.commands.install(['underscore'], undefined, config);


### PR DESCRIPTION
It should shows an error when `bower install` failed, fixes #922
- reason no bower.json in current directory

>  pretty sure it used to throw an error which was helpful because sometimes I'm in the wrong dir by mistake
