### PR TITLE
Fixed bower list --paths` fails with TypeError, fixes  #1383

### DIFF
--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -170,10 +170,16 @@ StandardRenderer.prototype._update = function (packages) {
 StandardRenderer.prototype._list = function (tree) {
     var cliTree;
 
-    tree.root = true;
-    cliTree = this._tree2archy(tree);
+    if (!tree.pkgMeta) {
+        cliTree = stringifyObject(tree, { indent: '  ' });
+    }
 
-    this._write(process.stdout, archy(cliTree));
+    if (tree.pkgMeta) {
+        tree.root = true;
+        cliTree = archy(this._tree2archy(tree));
+    }
+
+    this._write(process.stdout, cliTree);
 };
 
 StandardRenderer.prototype._search = function (results) {


### PR DESCRIPTION
Fixed `bower list --paths` fails with TypeError  #1383
