### PR TITLE
Add --full-depth flag to 'bower install'

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -15,6 +15,8 @@ function install(logger, endpoints, options, config) {
     if (options.save === undefined) {
         options.save = config.defaultSave;
     }
+    config.fullDepth = options.fullDepth || false;
+
     project = new Project(config, logger);
     tracker = new Tracker(config);
 
@@ -40,7 +42,8 @@ install.options = function (argv) {
         'force-latest': { type: Boolean, shorthand: 'F'},
         'production': { type: Boolean, shorthand: 'p' },
         'save': { type: Boolean, shorthand: 'S' },
-        'save-dev': { type: Boolean, shorthand: 'D' }
+        'save-dev': { type: Boolean, shorthand: 'D' },
+        'full-depth': { type: Boolean, shorthand: 'U' }
     }, argv);
 };
 

--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -113,7 +113,7 @@ GitRemoteResolver.prototype._fastClone = function (resolution) {
     args = ['clone',  this._source, '-b', branch, '--progress', '.'];
 
     // If the host does not support shallow clones, we don't use --depth=1
-    if (!GitRemoteResolver._noShallow.get(this._host)) {
+    if (!GitRemoteResolver._noShallow.get(this._host) && !this._config.fullDepth) {
         args.push('--depth', 1);
     }
 

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -38,4 +38,13 @@ describe('bower install', function () {
         });
     });
 
+    it.skip('installs package with --full-depth flag', function () {
+        var logger = bower.commands.install(['underscore'], {fullDepth: true}, config);
+
+        return helpers.expectEvent(logger, 'end')
+        .then(function () {
+            expect(bowerJson()).to.have.key('name');
+        });
+    });
+
 });


### PR DESCRIPTION
Added a --full-depth flag to 'bower install' which turns off the '--depth 1' flag when the GitRemoteResolver creates a 'git clone' command.

This is done by adding full-depth to the install command's list of options, with 'U' as the shorthand. The fullDepth options is then added to the config object. Alternatively, the options object could be passed all the way to GitRemoteResolver by way of the Project, Manager, and resolverFactory modules or the options object itself could be added to the config object.

As an enterprise user of Bower this was done to get around the issue of bower hanging at the checkout stage due to an issue with git's clone command when run using the --depth 1 flag on a https repo. Issue referenced here https://github.com/bower/bower/pull/886 and here https://github.com/bower/bower/issues/1257. 
