### PR TITLE
All slashes in package name will be replaced by "-" to support

### DIFF
--- a/lib/core/resolvers/Resolver.js
+++ b/lib/core/resolvers/Resolver.js
@@ -162,8 +162,9 @@ Resolver.clearRuntimeCache = function () {};
 Resolver.prototype._createTempDir = function () {
     return Q.nfcall(mkdirp, this._config.tmp)
     .then(function () {
+        var name = this._name.replace('/', '-'); // avoid subdirectories not supported by tmp.dir
         return Q.nfcall(tmp.dir, {
-            template: path.join(this._config.tmp, this._name + '-' + process.pid + '-XXXXXX'),
+            template: path.join(this._config.tmp, name + '-' + process.pid + '-XXXXXX'),
             mode: 0777 & ~process.umask(),
             unsafeCleanup: true
         });


### PR DESCRIPTION
tmp library that doesn't use recursive mkdir.

these changes are needed for new regexp of endpoint-parser https://github.com/bower/endpoint-parser/pull/9
