### PR TITLE
Disable shallow clones for all repos except those from github.com

### DIFF
--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -35,6 +35,9 @@ function GitHubResolver(decEndpoint, config, logger) {
     if (this._config.proxy || this._config.httpsProxy) {
         this._source = this._source.replace('git://', 'https://');
     }
+
+    // Enable shallow clones for GitHub repos
+    this._shallowClone = true;
 }
 
 util.inherits(GitHubResolver, GitRemoteResolver);

--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -25,6 +25,9 @@ function GitRemoteResolver(decEndpoint, config, logger) {
     } else {
         this._host = url.parse(this._source).host;
     }
+
+    // Disable shallow clones
+    this._shallowClone = false;
 }
 
 util.inherits(GitRemoteResolver, GitResolver);
@@ -113,7 +116,7 @@ GitRemoteResolver.prototype._fastClone = function (resolution) {
     args = ['clone',  this._source, '-b', branch, '--progress', '.'];
 
     // If the host does not support shallow clones, we don't use --depth=1
-    if (!GitRemoteResolver._noShallow.get(this._host)) {
+    if (this._shallowClone && !GitRemoteResolver._noShallow.get(this._host)) {
         args.push('--depth', 1);
     }
 


### PR DESCRIPTION
This PR disables shallow clones for all repos except those with github.com in the hostname. It does this by checking the hostname using a regex in the getOrgRepoPair method before setting the "--depth 1" flag. 

This is an update to the PR https://github.com/bower/bower/pull/1389 (Add --full-depth flag to 'bower install'). @sheerun mentioned we should disable all shallow clones instead of creating a new flag.

Note: The getOrgRepoPair method was moved from the GitHubResolver to the GitRemoteResolver so that it could be accessed by the GitRemoteResolver. Any module that called getOrgRepoPair was refactored to reflect the move.
