### PR TITLE
Allow Ignore For Child Dependencies

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -68,6 +68,9 @@ Manager.prototype.configure = function (setup) {
         }
     }, this);
 
+    // Dependencies to resolve ONLY if explicitly declared at top level. 
+    this._ignoredDependencies = setup.ignoredDependencies;
+
     // Resolutions
     this._resolutions = setup.resolutions || {};
 
@@ -397,6 +400,12 @@ Manager.prototype._parseDependencies = function (decEndpoint, pkgMeta, jsonKey) 
         var fetching;
         var compatible;
         var childDecEndpoint = endpointParser.json2decomposed(key, value);
+
+        // Check if this depdendency should be skipped.
+        if (mout.array.contains(this._ignoredDependencies, childDecEndpoint.name)) {
+            this._logger.action('skipped', childDecEndpoint.name, this.toData(decEndpoint));
+            return;
+        }
 
         // Check if a compatible one is already resolved
         // If there's one, we don't need to resolve it twice
@@ -981,5 +990,5 @@ Manager.prototype._uniquify = function (decEndpoints) {
         return true;
     });
 };
-
+ 
 module.exports = Manager;

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -521,7 +521,8 @@ Project.prototype._bootstrap = function (targets, resolved, incompatibles) {
         incompatibles: incompatibles,
         resolutions: this._json.resolutions,
         installed: installed,
-        forceLatest: this._options.forceLatest
+        forceLatest: this._options.forceLatest,
+        ignoredDependencies: this._json.ignoredDependencies || []
     })
     .resolve()
     .then(function () {


### PR DESCRIPTION
Fix for bug #927. Ignore package if name matches specified in bower.json.
Permit fetch if package is explicitly declared in dependencies or devDependencies.
Designed for users who need tighter control of versions due to corporate liscence restrictions or other reasons.