### PR TITLE
Fix createTempDir use of tmp package

### DIFF
--- a/lib/core/resolvers/Resolver.js
+++ b/lib/core/resolvers/Resolver.js
@@ -168,10 +168,9 @@ Resolver.prototype._createTempDir = function () {
             unsafeCleanup: true
         });
     }.bind(this))
-    .then(function (results) {
-        var tempDir = results[0];
-        this._tempDir = tempDir;
-        return tempDir;
+    .spread(function (dir) {
+        this._tempDir = dir;
+        return dir;
     }.bind(this));
 };
 


### PR DESCRIPTION
The tmp package updated it's API to return a cleanup callback in addition to just the directory name. Q then squashes the two arguments to the callback into an array, while bower expected just a string for the directory name.

This causes "TypeError: Arguments to path.join must be strings" errors to appear, seemingly non-deterministic, because various spots attempt to use the `_tempDir` value (now an array) to join into a path.

semver ftw!

edit: added error details for those searching
