### PR TITLE
Basic fix for issue #1413

### DIFF
--- a/lib/core/resolvers/Resolver.js
+++ b/lib/core/resolvers/Resolver.js
@@ -172,8 +172,8 @@ Resolver.prototype._createTempDir = function () {
         if (typeof dir === 'string') {
             this._tempDir = dir;
         } else {
-          // Issue #1413 where 'dir' is being returned as an array not a string.
-          this._tempDir = dir[0];
+            // Issue #1413 where 'dir' is being returned as an array not a string.
+            this._tempDir = dir[0];
         }
         
         return dir;


### PR DESCRIPTION
The 'dir' variable is not handed to the callback as a string, in every
Windows installation of 1.3.8 it is being returned as an array because
of the tmp dependency being updated. The details of this failure are
highlighted in issue #1413 and is a major blocker in using Bower
successfully on Windows.

Pull request #1407 can be ignored if this code fix is in place instead
which supports both return variations of tmp.dir.
