### PR TITLE
Fix "TypeError: Arguments to path.join must be strings" in GitHubResolver

### DIFF
--- a/lib/core/resolvers/Resolver.js
+++ b/lib/core/resolvers/Resolver.js
@@ -169,8 +169,8 @@ Resolver.prototype._createTempDir = function () {
         });
     }.bind(this))
     .then(function (dir) {
-        this._tempDir = dir;
-        return dir;
+        // nfcall may return multiple callback arguments as an array
+        return this._tempDir = Array.isArray(dir) ? dir[0] : dir;
     }.bind(this));
 };
 


### PR DESCRIPTION
When tmp.js returns a cleanup callback in addition to the tmp dir path, nfcall changes return type to an array. 
