### PR TITLE
analytics - bump insight, supports OS/node/CLI version tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "graceful-fs": "~3.0.1",
     "handlebars": "~1.3.0",
     "inquirer": "~0.5.1",
-    "insight": "~0.3.0",
+    "insight": "~0.4.1",
     "is-root": "~0.1.0",
     "junk": "~0.3.0",
     "lockfile": "~0.4.2",


### PR DESCRIPTION
Per @sheerun's request: https://github.com/bower/bower/issues/1164#issuecomment-45727838

Insight 0.4's change: https://github.com/yeoman/insight/commit/1b24f9135a6b1ffa5ce7dfd80383d49facbbddb9

This will provide analytics like this: http://david-smith.org/iosversionstats/, which will allow the team to debug and consider legacy support. Unfortunately data will only be available going forward.
