### PR TITLE
Added .zip MIME type (e.g. the default served by Windows/IIS)

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -23,6 +23,7 @@ extractors = {
     '.gz': extractGz,
     'application/zip': extractZip,
     'application/x-zip': extractZip,
+    'application/x-zip-compressed': extractZip,
     'application/x-tar': extractTar,
     'application/x-tgz': extractTarGz,
     'application/x-gzip': extractGz


### PR DESCRIPTION
Just found that .zip dependencies served behind IIS contains an unrecognized (but standard, it seems) MIME header.
Just adding that 'x-zip-compressed' to the list of known types fixes the issue.
Not sure about the other package MIME types, so I've left it as is.
Thank you,
 Luciano
