### PR TITLE
Bump request to ~2.40. Fixes #1452

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "p-throttler": "0.0.1",
     "promptly": "~0.2.0",
     "q": "~1.0.1",
-    "request": "~2.36.0",
+    "request": "~2.40.0",
     "request-progress": "~0.3.0",
     "retry": "~0.6.0",
     "rimraf": "~2.2.0",


### PR DESCRIPTION
Fixes https://github.com/bower/bower/issues/1452

request ~2.40 addresses: https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
