### PR TITLE
Mention updates in the main help

### DIFF
--- a/templates/json/help.json
+++ b/templates/json/help.json
@@ -10,7 +10,7 @@
         "init":            "Interactively create a bower.json file",
         "install":         "Install a package locally",
         "link":            "Symlink a package folder",
-        "list":            "List local packages",
+        "list":            "List local packages - and possible updates",
         "lookup":          "Look up a package URL by name",
         "prune":           "Removes local extraneous packages",
         "register":        "Register a package",


### PR DESCRIPTION
See #955. The same was done for `bower list -h`, but not for `bower help` AKA just `bower`.
