### PR TITLE
"analytics" value in `.bowerrc` removes need to prompt user

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,13 +16,6 @@ if (config.interactive == null) {
     );
 }
 
-// If `analytics` hasn't been explicitly set, we disable
-// it when ran programatically.
-if (config.analytics == null) {
-    // Don't enable analytics on CI server unless explicitly configured.
-    config.analytics = config.interactive;
-}
-
 // Merge common CLI options into the config
 mout.object.mixIn(config, cli.readOptions({
     force: { type: Boolean, shorthand: 'f' },

--- a/lib/util/analytics.js
+++ b/lib/util/analytics.js
@@ -9,24 +9,39 @@ var insight;
 analytics.setup = function setup(config) {
     var deferred = Q.defer();
 
-    // Display the ask prompt only if it hasn't been answered before
-    // and the current session is looking to configure the analytics.
-    if (config.analytics) {
+    // if `analytics` hasn't been explicitly set
+    if (config.analytics == null) {
         var Insight = require('insight');
         var pkg = require('../../package.json');
-
         insight = new Insight({
             trackingCode: 'UA-43531210-1',
             packageName: pkg.name,
             packageVersion: pkg.version
         });
 
-        if (insight.optOut === undefined) {
-            insight.askPermission(null, deferred.resolve);
-        } else {
+        // if there is a stored value
+        if (insight.optOut !== undefined) {
+            // set analytics to the stored value
+            config.analytics = !insight.optOut;
             deferred.resolve();
+        } else {
+            if (config.interactive) {
+                // prompt the user if this is an interactive session
+                insight.askPermission(null, function(err, optOut) {
+                    // value is the *opposite* of user response
+                    // https://github.com/yeoman/insight/issues/31
+                    config.analytics = !optOut;
+                    deferred.resolve();
+                });
+            } else {
+                // no specified value, no stored value, and can't prompt for one
+                // so set analytics to true
+                config.analytics = true;
+                deferred.resolve();
+            }
         }
     } else {
+        // use the specified value
         deferred.resolve();
     }
 


### PR DESCRIPTION
**Goal:** prevent all prompting for analytics without adding CLI args to every `bower` invocation.

Currently, specifying `"analytics": false`  in `.bowerrc` will prevent the prompt, but `"analytics": true` will not. There is no need to prompt the user if the answer is supplied via args _or_ `.bowerrc`.

I'd love to supply tests, but didn't see any existing ones to extend. Please let me know how you'd like me to test these changes. While developing, I had `console.log` statements in each branch, here's a log of several different scenarios:

```
# no .bowerrc, no stored value, no CLI
> ./bin/bower
no explicit analytics value
stored analytics value true

# no .bowerrc, no stored value, CLI option
> ./bin/bower --config.analytics=false
use the specified value of false

# no .bowerrc, no stored value, CLI option
> ./bin/bower --config.analytics=true
use the specified value of true

# no .bowerrc, no stored value, CLI option
> ./bin/bower --config.interactive=true
no explicit analytics value
no stored value
is interactive
[?] May bower anonymously report usage statistics to improve the tool over time? (Y/n)

# no .bowerrc, no stored value, CLI option
> ./bin/bower --config.interactive=false
no explicit analytics value
no stored value
is not interactive, set analytics to false

# .bowerrc analytics=false, no stored value, no cli
> ./bin/bower
use the specified value of false

# .bowerrc analytics=true, no stored value, no cli
> ./bin/bower
use the specified value of true

# .bowerrc interactive=false, no stored value, no cli
> ./bin/bower
no explicit analytics value
no stored value
is not interactive, set analytics to false

# .bowerrc interactive=true, no stored value, no cli
> ./bin/bower
no explicit analytics value
no stored value
is interactive
[?] May bower anonymously report usage statistics to improve the tool over time? (Y/n)

# no .bowerrc, stored value true (optOut=false), no CLI
> ./bin/bower
no explicit analytics value
stored analytics value true

# no .bowerrc, stored value false (optOut=true), no CLI
> ./bin/bower
no explicit analytics value
stored analytics value false
```
