### PR TITLE
expose bower version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var abbrev = require('abbrev');
 var mout = require('mout');
 var commands = require('./commands');
+var pkg = require('../package.json');
 
 var abbreviations = abbrev(expandNames(commands));
 abbreviations.i = 'install';
@@ -34,6 +35,7 @@ function clearRuntimeCache() {
 }
 
 module.exports = {
+    version: pkg.version,
     commands: commands,
     config: require('./config'),
     abbreviations: abbreviations,


### PR DESCRIPTION
It would be great if bower exposes the version when using it programmatically.

That would help with https://github.com/stefanpenner/ember-cli/issues/1698
