### PR TITLE
Use `tar-fs` instead of `tar` for faster TAR extraction

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('graceful-fs');
 var zlib = require('zlib');
 var DecompressZip = require('decompress-zip');
-var tar = require('tar');
+var tar = require('tar-fs');
 var Q = require('q');
 var mout = require('mout');
 var junk = require('junk');
@@ -51,13 +51,11 @@ function extractTar(archive, dst) {
 
     fs.createReadStream(archive)
     .on('error', deferred.reject)
-    .pipe(tar.Extract({
-        path: dst,
-        follow: false,           // Do not follow symlinks (#699)
-        filter: filterSymlinks   // Filter symlink files
+    .pipe(tar.extract(dst, {
+        ignore: isSymlink  // Filter symlink files
     }))
     .on('error', deferred.reject)
-    .on('close', deferred.resolve.bind(deferred, dst));
+    .on('finish', deferred.resolve.bind(deferred, dst));
 
     return deferred.promise;
 }
@@ -69,13 +67,11 @@ function extractTarGz(archive, dst) {
     .on('error', deferred.reject)
     .pipe(zlib.createGunzip())
     .on('error', deferred.reject)
-    .pipe(tar.Extract({
-        path: dst,
-        follow: false,           // Do not follow symlinks (#699)
-        filter: filterSymlinks   // Filter symlink files
+    .pipe(tar.extract(dst, {
+        ignore: isSymlink  // Filter symlink files
     }))
     .on('error', deferred.reject)
-    .on('close', deferred.resolve.bind(deferred, dst));
+    .on('finish', deferred.resolve.bind(deferred, dst));
 
     return deferred.promise;
 }
@@ -92,6 +88,10 @@ function extractGz(archive, dst) {
     .on('close', deferred.resolve.bind(deferred, dst));
 
     return deferred.promise;
+}
+
+function isSymlink(entry) {
+    return entry.type === 'SymbolicLink';
 }
 
 function filterSymlinks(entry) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "semver": "~2.3.0",
     "shell-quote": "~1.4.1",
     "stringify-object": "~0.2.0",
-    "tar": "~0.1.17",
+    "tar-fs": "~0.5.0",
     "tmp": "0.0.23",
     "update-notifier": "~0.2.0",
     "which": "~1.0.5"

--- a/test/core/resolvers/urlResolver.js
+++ b/test/core/resolvers/urlResolver.js
@@ -1,7 +1,6 @@
 var expect = require('expect.js');
 var path = require('path');
 var fs = require('graceful-fs');
-var path = require('path');
 var nock = require('nock');
 var Q = require('q');
 var rimraf = require('rimraf');


### PR DESCRIPTION
Closes #1440.
