### PR TITLE
svn subdirectory checkouts

### DIFF
--- a/lib/core/resolvers/SvnResolver.js
+++ b/lib/core/resolvers/SvnResolver.js
@@ -32,12 +32,37 @@ mout.object.mixIn(SvnResolver, Resolver);
 // -----------------
 
 SvnResolver.getSource = function (source) {
-    var uri = this._source || source;
+    var uri = typeof source === 'object' ? source.original : this._source || source;
+    var trunkIndex;
+    var branchIndex;
+    var tagIndex;
+    var base;
 
-    return uri
+    uri = uri
         .replace(/^svn\+(https?|file):\/\//i, '$1://')  // Change svn+http or svn+https or svn+file to http(s), file respectively
         .replace('svn://', 'http://')  // Change svn to http
         .replace(/\/+$/, '');  // Remove trailing slashes
+
+    base = source.base;
+
+    trunkIndex = uri.indexOf('/trunk');
+    branchIndex = uri.indexOf('/branches/');
+    tagIndex = uri.indexOf('/tag');
+
+    if (trunkIndex > 0) {
+      base = uri.slice(0, trunkIndex);
+    }
+    else if (branchIndex > 0) {
+      base = uri.slice(0, branchIndex);
+    }
+    else if (tagIndex > 0) {
+      base = uri.slice(0, tagIndex);
+    }
+
+    return {
+      original: uri,
+      base: base
+    };
 };
 
 SvnResolver.prototype._hasNew = function (canonicalDir, pkgMeta) {
@@ -77,6 +102,7 @@ SvnResolver.prototype._export = function () {
     var reporter;
     var that = this;
     var resolution = this._resolution;
+    var useOriginalUrl = this._source.original !== this._source.base;
 
     this.source = SvnResolver.getSource(this._source);
 
@@ -85,14 +111,17 @@ SvnResolver.prototype._export = function () {
         to: this._tempDir
     });
 
+    if (useOriginalUrl) {
+        promise = cmd('svn', ['export', '--force', this._source.original, this._tempDir]);
+    }
     if (resolution.type === 'commit') {
-        promise = cmd('svn', ['export', '--force', this._source + '/trunk', '-r' + resolution.commit, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source.original + '/trunk', '-r' + resolution.commit, this._tempDir]);
     } else if (resolution.type === 'branch' && resolution.branch === 'trunk') {
-        promise = cmd('svn', ['export', '--force', this._source + '/trunk', this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source.original + '/trunk', this._tempDir]);
     } else if (resolution.type === 'branch') {
-        promise = cmd('svn', ['export', '--force', this._source + '/branches/' + resolution.branch, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source.original + '/branches/' + resolution.branch, this._tempDir]);
     } else {
-        promise = cmd('svn', ['export', '--force', this._source + '/tags/' + resolution.tag, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', this._source.original + '/tags/' + resolution.tag, this._tempDir]);
     }
 
     // Throttle the progress reporter to 1 time each sec
@@ -261,6 +290,7 @@ SvnResolver.prototype._savePkgMeta = function (meta) {
 
 // ------------------------------
 
+
 SvnResolver.versions = function (source, extra) {
     source = SvnResolver.getSource(source);
 
@@ -324,7 +354,7 @@ SvnResolver.tags = function (source) {
         return Q.resolve(value);
     }
 
-    value = cmd('svn', ['list', source + '/tags', '--verbose'])
+    value = cmd('svn', ['list', source.base + '/tags', '--verbose'])
     .spread(function (stout) {
         var tags = SvnResolver.parseSubversionListOutput(stout.toString());
 
@@ -343,13 +373,13 @@ SvnResolver.tags = function (source) {
 SvnResolver.branches = function (source) {
     source = SvnResolver.getSource(source);
 
-    var value = this._cache.branches.get(source);
+    var value = this._cache.branches.get(source.original);
 
     if (value) {
         return Q.resolve(value);
     }
 
-    value = cmd('svn', ['list', source + '/branches', '--verbose'])
+    value = cmd('svn', ['list', source.base + '/branches', '--verbose'])
     .spread(function (stout) {
         var branches = SvnResolver.parseSubversionListOutput(stout.toString());
 

--- a/test/core/resolverFactory.js
+++ b/test/core/resolverFactory.js
@@ -383,7 +383,7 @@ describe('resolverFactory', function () {
             .then(function (resolver) {
                 expect(resolver).to.be.a(resolvers.Svn);
                 expect(resolver).to.not.be(resolvers.GitHub);
-                expect(resolvers.Svn.getSource(resolver.getSource())).to.equal(value);
+                expect(resolvers.Svn.getSource(resolver.getSource().original)).to.equal(value);
                 expect(resolver.getTarget()).to.equal('*');
             });
 


### PR DESCRIPTION
so this is just something I was messing with before dinner, and have no real expectation of merging. The code is real hackey, and needs to be properly written, however I think it is neat enough to show the team and see if there is any interest in continuing it.

currently svn checkouts can only work with the root of svn repos (at least all of the svn repos I've tried it with). I wouldn't normally give two hoots about svn, however, github offers a wonderful svn mirroring service. As a result, the svn client works against all github repos.

So, if you have a very large and popular repo that is not offically published to bower. Say....underscore.js. And really only want the one file that would exist in the `main` field, you could do

`bower install "svn+https://github.com/jashkenas/underscore/trunk/underscore-min.js"`

and then end up with 

```
bower_components
└── underscore-min.js
    └── underscore-min.js
```

Tests are currently broken, and theres a load of polish that needs to be put on, but its a technically working POC
