### PR TITLE
Fixed search results line spacing

### DIFF
--- a/templates/std/search-results.std
+++ b/templates/std/search-results.std
@@ -7,5 +7,8 @@
 {{/condense}}
 
 
-{{else}}No results.
+{{else}}
+
+No results.
+
 {{/if}}


### PR DESCRIPTION
After running `bower search`, with a valid search, the input was returned on the current line. I adding spacing after the search results.

After running `bower search`, with an unsuccessful query, the `No Results.` message was returned without spacing. I added a line return before and after the message for constancy with a successful search return.
