### PR TITLE
[fix] Ensure extracted files are readable, update tar-fs

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -52,7 +52,9 @@ function extractTar(archive, dst) {
     fs.createReadStream(archive)
     .on('error', deferred.reject)
     .pipe(tar.extract(dst, {
-        ignore: isSymlink  // Filter symlink files
+        ignore: isSymlink, // Filter symlink files
+        dmode: 0555,       // Ensure dirs are readable
+        fmode: 0444        // Ensure files are readable
     }))
     .on('error', deferred.reject)
     .on('finish', deferred.resolve.bind(deferred, dst));
@@ -68,7 +70,9 @@ function extractTarGz(archive, dst) {
     .pipe(zlib.createGunzip())
     .on('error', deferred.reject)
     .pipe(tar.extract(dst, {
-        ignore: isSymlink  // Filter symlink files
+        ignore: isSymlink, // Filter symlink files
+        dmode: 0555,       // Ensure dirs are readable
+        fmode: 0444        // Ensure files are readable
     }))
     .on('error', deferred.reject)
     .on('finish', deferred.resolve.bind(deferred, dst));

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "semver": "~2.3.0",
     "shell-quote": "~1.4.1",
     "stringify-object": "~1.0.0",
-    "tar-fs": "0.5.2",
+    "tar-fs": "~1.0.0",
     "tmp": "0.0.23",
     "update-notifier": "0.2.0",
     "which": "~1.0.5"


### PR DESCRIPTION
tar-fs README suggest that for improved windows experience:

> It can be useful to use dmode and fmode if you are packing/unpacking tarballs between *nix/windows to ensure that all files/directories unpacked are readable.
