### PR TITLE
Configuration support for enabling/disabling shallow cloning

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -28,6 +28,16 @@ function GitRemoteResolver(decEndpoint, config, logger) {
 
     // Disable shallow clones
     this._shallowClone = false;
+
+    // Check whether a configuration for the specified host exists
+    var configHost = mout.array.find(config.hosts, function(host) {
+        return host.name === this._host;
+    }, this);
+
+    // If the configured host has a setting for shallowClone, use that - otherwise use _false_.
+    if (configHost) {
+        this._shallowClone = configHost.shallowClone || false;
+    }
 }
 
 util.inherits(GitRemoteResolver, GitResolver);


### PR DESCRIPTION
Added a configuration option in the .bowerrc file to allow enabling/disabling the shallow clone feature per host.

This fixes #1558. Let me know if the configuration is acceptable. Another option would be to provide an array or comma separated list of hosts which allow shallow cloning, but this format provides greater flexibility. Let me know if you would like to see changes.

Since this adds a new option to the `.bowerrc` file, the documentation needs to be updated as well. Let me know if you want me to do this.

The configuration looks like this:

```
{
    "hosts": [
        {
            "name": "git.myservice.com",
            "shallowClone": true
        }
    ]
}
```

The `hosts` element accepts an array of host entries, each one with a `name` and a `shallowClone` attribute. The name of the host is matched against the target host in the clone/install command.

If the target host is not part of the configuration, or no `hosts` configuration has been provided at all, Bower defaults to _false_ for the shallow clone feature, the current default behavior for all non-GitHub repos.

I hope this addresses the issue described in #1389, #886 and #1393, which took a bit of a shotgun approach by disabling shallow cloning for everyone, even for hosts where it worked perfectly fine. I would like to see this PR (or a similar option) in Bower to allow a flexible setting for everyone. For us, disabling shallow cloning has a huge performance impact on our build process - and I would like to get that fixed as soon as possible.

Let me know if this PR (my first for Bower) is acceptable or whether you would like to see changes. Adapting the configuration to a different format shouldn't be too difficult.
