### PR TITLE
Add special Git resolver for BitBucket

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -6,6 +6,7 @@ var endpointParser = require('bower-endpoint-parser');
 var Project = require('../core/Project');
 var defaultConfig = require('../config');
 var GitHubResolver = require('../core/resolvers/GitHubResolver');
+var BitBucketResolver = require('../core/resolvers/BitBucketResolver');
 var GitFsResolver = require('../core/resolvers/GitFsResolver');
 var cli = require('../util/cli');
 var cmd = require('../util/cmd');
@@ -115,7 +116,7 @@ function setDefaults(config, json) {
 
     // Homepage
     if (!json.homepage) {
-        // Set as GitHub homepage if it's a GitHub repository
+        // Set as GitHub/Bitbucket homepage if it's a GitHub/Bitbucket repository
         promise = promise.then(function () {
             return cmd('git', ['config', '--get', 'remote.origin.url'])
             .spread(function (stdout) {
@@ -129,6 +130,11 @@ function setDefaults(config, json) {
                 pair = GitHubResolver.getOrgRepoPair(stdout);
                 if (pair) {
                     json.homepage = 'https://github.com/' + pair.org + '/' + pair.repo;
+                }
+
+                pair = BitBucketResolver.getOrgRepoPair(stdout);
+                if (pair) {
+                    json.homepage = 'https://bitbucket.org/' + pair.org + '/' + pair.repo;
                 }
             })
             .fail(function () { });

--- a/lib/commands/register.js
+++ b/lib/commands/register.js
@@ -8,6 +8,7 @@ var cli = require('../util/cli');
 var createError = require('../util/createError');
 var defaultConfig = require('../config');
 var GitHubResolver = require('../core/resolvers/GitHubResolver');
+var BitBucketResolver = require('../core/resolvers/BitBucketResolver');
 
 function register(logger, name, url, config) {
     var repository;
@@ -91,10 +92,16 @@ function convertUrl(url, logger) {
     var newUrl;
 
     if (!mout.string.startsWith(url, 'git://')) {
-        // Convert GitHub ssh & https to git://
+        // Convert GitHub/Bitbucket ssh & https to git://
         pair = GitHubResolver.getOrgRepoPair(url);
         if (pair) {
             newUrl = 'git://github.com/' + pair.org + '/' + pair.repo + '.git';
+            logger.warn('convert', 'Converted ' + url + ' to ' + newUrl);
+        }
+
+        pair = BitBucketResolver.getOrgRepoPair(url);
+        if (pair) {
+            newUrl = 'git://bitbucket.org/' + pair.org + '/' + pair.repo + '.git';
             logger.warn('convert', 'Converted ' + url + ' to ' + newUrl);
         }
     }

--- a/lib/core/resolverFactory.js
+++ b/lib/core/resolverFactory.js
@@ -41,6 +41,11 @@ function getConstructor(source, config, registryClient) {
                 return [resolvers.GitHub, source];
             }
 
+            // If it's a BitBucket repository, return the specialized resolver
+            if (resolvers.BitBucket.getOrgRepoPair(source)) {
+                return [resolvers.BitBucket, source];
+            }
+
             return [resolvers.GitRemote, source];
         });
     }

--- a/lib/core/resolvers/BitBucketResolver.js
+++ b/lib/core/resolvers/BitBucketResolver.js
@@ -1,0 +1,148 @@
+var util = require('util');
+var path = require('path');
+var mout = require('mout');
+var GitRemoteResolver = require('./GitRemoteResolver');
+var download = require('../../util/download');
+var extract = require('../../util/extract');
+var createError = require('../../util/createError');
+
+function BitBucketResolver(decEndpoint, config, logger) {
+    var pair;
+
+    GitRemoteResolver.call(this, decEndpoint, config, logger);
+
+    // Grab the org/repo
+    // /xxxxx/yyyyy.git or :xxxxx/yyyyy.git (.git is optional)
+    pair = BitBucketResolver.getOrgRepoPair(this._source);
+    if (!pair) {
+        throw createError('Invalid BitBucket URL', 'EINVEND', {
+            details: this._source + ' does not seem to be a valid BitBucket URL'
+        });
+    }
+
+    this._org = pair.org;
+    this._repo = pair.repo;
+
+    // Ensure trailing for all protocols
+    if (!mout.string.endsWith(this._source, '.git')) {
+        this._source += '.git';
+    }
+
+    // Check if it's public
+    this._public = mout.string.startsWith(this._source, 'https://');
+
+    // Use https:// rather than git://
+    this._source = this._source.replace('git://', 'https://');
+
+    // Enable shallow clones for BitBucket repos
+    this._shallowClone = true;
+}
+
+util.inherits(BitBucketResolver, GitRemoteResolver);
+mout.object.mixIn(BitBucketResolver, GitRemoteResolver);
+
+// -----------------
+
+BitBucketResolver.prototype._checkout = function () {
+    // Only fully works with public repositories and tags
+    // Could work with https/ssh protocol but not with 100% certainty
+    if (!this._public || !this._resolution.tag) {
+        return GitRemoteResolver.prototype._checkout.call(this);
+    }
+
+    var msg;
+    var tarballUrl = 'https://bitbucket.org/' + this._org + '/' + this._repo + '/get/' + this._resolution.tag + '.tar.gz';
+    var file = path.join(this._tempDir, 'archive.tar.gz');
+    var reqHeaders = {};
+    var that = this;
+
+    if (this._config.userAgent) {
+        reqHeaders['User-Agent'] = this._config.userAgent;
+    }
+
+    this._logger.action('download', tarballUrl, {
+        url: that._source,
+        to: file
+    });
+
+    // Download tarball
+    return download(tarballUrl, file, {
+        proxy: this._config.httpsProxy,
+        strictSSL: this._config.strictSsl,
+        timeout: this._config.timeout,
+        headers: reqHeaders
+    })
+    .progress(function (state) {
+        // Retry?
+        if (state.retry) {
+            msg = 'Download of ' + tarballUrl + ' failed with ' + state.error.code + ', ';
+            msg += 'retrying in ' + (state.delay / 1000).toFixed(1) + 's';
+            that._logger.debug('error', state.error.message, { error: state.error });
+            return that._logger.warn('retry', msg);
+        }
+
+        // Progress
+        msg = 'received ' + (state.received / 1024 / 1024).toFixed(1) + 'MB';
+        if (state.total) {
+            msg += ' of ' + (state.total / 1024 / 1024).toFixed(1) + 'MB downloaded, ';
+            msg += state.percent + '%';
+        }
+        that._logger.info('progress', msg);
+    })
+    .then(function () {
+        // Extract archive
+        that._logger.action('extract', path.basename(file), {
+            archive: file,
+            to: that._tempDir
+        });
+
+        return extract(file, that._tempDir)
+        // Fallback to standard git clone if extraction failed
+        .fail(function (err) {
+            msg =  'Decompression of ' + path.basename(file) + ' failed' + (err.code ? ' with ' + err.code : '') + ', ';
+            msg += 'trying with git..';
+            that._logger.debug('error', err.message, { error: err });
+            that._logger.warn('retry', msg);
+
+            return that._cleanTempDir()
+            .then(GitRemoteResolver.prototype._checkout.bind(that));
+        });
+    // Fallback to standard git clone if download failed
+    }, function (err) {
+        msg = 'Download of ' + tarballUrl + ' failed' + (err.code ? ' with ' + err.code : '') + ', ';
+        msg += 'trying with git..';
+        that._logger.debug('error', err.message, { error: err });
+        that._logger.warn('retry', msg);
+
+        return that._cleanTempDir()
+        .then(GitRemoteResolver.prototype._checkout.bind(that));
+
+    });
+};
+
+BitBucketResolver.prototype._savePkgMeta = function (meta) {
+    // Set homepage if not defined
+    if (!meta.homepage) {
+        meta.homepage = 'https://bitbucket.org/' + this._org + '/' + this._repo;
+    }
+
+    return GitRemoteResolver.prototype._savePkgMeta.call(this, meta);
+};
+
+// ----------------
+
+BitBucketResolver.getOrgRepoPair = function (url) {
+    var match;
+
+    match = url.match(/(?:@|:\/\/)bitbucket.org[:\/]([^\/\s]+?)\/([^\/\s]+?)(?:\.git)?\/?$/i);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        org: match[1],
+        repo: match[2]
+    };
+};
+
+module.exports = BitBucketResolver;

--- a/lib/core/resolvers/index.js
+++ b/lib/core/resolvers/index.js
@@ -2,6 +2,7 @@ module.exports = {
     GitFs: require('./GitFsResolver'),
     GitRemote: require('./GitRemoteResolver'),
     GitHub: require('./GitHubResolver'),
+    BitBucket: require('./BitBucketResolver'),
     Svn: require('./SvnResolver'),
     Fs: require('./FsResolver'),
     Url: require('./UrlResolver')

--- a/test/core/resolvers/bitBucketResolver.js
+++ b/test/core/resolvers/bitBucketResolver.js
@@ -1,0 +1,171 @@
+var path = require('path');
+var nock = require('nock');
+var fs = require('graceful-fs');
+var expect = require('expect.js');
+var Logger = require('bower-logger');
+var GitRemoteResolver  = require('../../../lib/core/resolvers/GitRemoteResolver');
+var BitBucketResolver = require('../../../lib/core/resolvers/BitBucketResolver');
+var defaultConfig = require('../../../lib/config');
+
+describe('BitBucket', function () {
+    var logger;
+    var testPackage = path.resolve(__dirname, '../../assets/package-a');
+
+    before(function () {
+        logger = new Logger();
+    });
+
+    afterEach(function () {
+        // Clean nocks
+        nock.cleanAll();
+
+        logger.removeAllListeners();
+    });
+
+    function create(decEndpoint) {
+        if (typeof decEndpoint === 'string') {
+            decEndpoint = { source: decEndpoint };
+        }
+
+        return new BitBucketResolver(decEndpoint, defaultConfig({ strictSsl: false }), logger);
+    }
+
+    describe('.constructor', function () {
+        it.skip('should throw an error on invalid BitBucket URLs');
+
+        it('should ensure .git in the source', function () {
+            var resolver;
+
+            resolver = create('https://bitbucket.org/drublic/bower-test');
+            expect(resolver.getSource()).to.equal('https://bitbucket.org/drublic/bower-test.git');
+
+            resolver = create('https://bitbucket.org/drublic/bower-test.git');
+            expect(resolver.getSource()).to.equal('https://bitbucket.org/drublic/bower-test.git');
+
+            resolver = create('https://bitbucket.org/drublic/bower-test.git/');
+            expect(resolver.getSource()).to.equal('https://bitbucket.org/drublic/bower-test.git');
+        });
+    });
+
+    describe('.resolve', function () {
+
+        this.timeout(10000);  // Give some time to execute
+
+        it('should download and extract the .tar.gz archive from bitbucket.org', function (next) {
+            var resolver;
+
+            nock('https://bitbucket.org')
+            .get('/drublic/bower-test/get/0.1.0.tar.gz')
+            .replyWithFile(200, path.resolve(__dirname, '../../assets/package-tar.tar.gz'));
+
+            resolver = create({ source: 'git@bitbucket.org:drublic/bower-test.git', target: '0.1.0' });
+            resolver.resolve()
+            .then(function (dir) {
+                expect(fs.existsSync(path.join(dir, 'foo'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'bar'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'bar'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, '.bower.json'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'README.md'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'package-tar.tar.gz'))).to.be(false);
+                expect(fs.existsSync(path.join(dir, 'package-tar.tar'))).to.be(false);
+                next();
+            })
+            .done();
+        });
+
+        it('should retry using the GitRemoteResolver mechanism if download failed', function (next) {
+            var resolver;
+            var retried;
+
+            nock('https://bitbucket.org')
+            .get('/drublic/bower-test/get/0.1.0.tar.gz')
+            .reply(200, 'this is not a valid tar');
+
+            logger.on('log', function (entry) {
+                if (entry.level === 'warn' && entry.id === 'retry') {
+                    retried = true;
+                }
+            });
+
+            resolver = create({ source: 'https://bitbucket.org/drublic/bower-test.git', target: '0.1.0' });
+
+            // Monkey patch source to file://
+            resolver._source = 'file://' + testPackage;
+
+            resolver.resolve()
+            .then(function (dir) {
+                expect(retried).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'foo'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'bar'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'baz'))).to.be(true);
+                next();
+            })
+            .done();
+        });
+
+        it('should retry using the GitRemoteResolver mechanism if extraction failed', function (next) {
+            var resolver;
+            var retried;
+
+            nock('https://bitbucket.org')
+            .get('/drublic/bower-test/get/0.1.0.tar.gz')
+            .reply(500);
+
+            logger.on('log', function (entry) {
+                if (entry.level === 'warn' && entry.id === 'retry') {
+                    retried = true;
+                }
+            });
+
+            resolver = create({ source: 'https://bitbucket.org/drublic/bower-test.git', target: '0.1.0' });
+
+            // Monkey patch source to file://
+            resolver._source = 'file://' + testPackage;
+
+            resolver.resolve()
+            .then(function (dir) {
+                expect(retried).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'foo'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'bar'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'baz'))).to.be(true);
+                next();
+            })
+            .done();
+        });
+
+        it('should fallback to the GitRemoteResolver mechanism if resolution is not a tag', function (next) {
+            var resolver = create({ source: 'https://bitbucket.org/drublic/bower-test.git', target: '2af02ac6ddeaac1c2f4bead8d6287ce54269c039' });
+            var originalCheckout = GitRemoteResolver.prototype._checkout;
+            var called;
+
+            GitRemoteResolver.prototype._checkout = function () {
+                called = true;
+                return originalCheckout.apply(this, arguments);
+            };
+
+            // Monkey patch source to file://
+            resolver._source = 'file://' + testPackage;
+
+            resolver.resolve()
+            .then(function (dir) {
+                expect(fs.existsSync(path.join(dir, 'foo'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'bar'))).to.be(true);
+                expect(fs.existsSync(path.join(dir, 'baz'))).to.be(true);
+                expect(called).to.be(true);
+                next();
+            })
+            .fin(function () {
+                GitRemoteResolver.prototype._checkout = originalCheckout;
+            })
+            .done();
+        });
+
+        it.skip('it should error out if the status code is not within 200-299');
+
+        it.skip('should report progress if it takes too long to download');
+    });
+
+    describe('._savePkgMeta', function () {
+        it.skip('should guess the homepage if not already set');
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ require('./core/resolvers/gitResolver');
 require('./core/resolvers/gitFsResolver');
 require('./core/resolvers/gitRemoteResolver');
 require('./core/resolvers/gitHubResolver');
+require('./core/resolvers/bitBucketResolver');
 require('./core/resolvers/svnResolver');
 require('./core/resolverFactory');
 require('./core/resolveCache');


### PR DESCRIPTION
This commit adds a BitBucket resolver for packages hosted on BitBucket
with shallow cloning. It includes everything the GitHub resolver
includes but for BitBucket.

All test run now with the change in mocha's timeout option which is not so great. Is there a better (maybe correct) way to use nock here to mock the BitBucket request?

Ref.: #1564
