### PR TITLE
Add extra newline at the end of help-cache.std

### DIFF
--- a/templates/std/help-cache.std
+++ b/templates/std/help-cache.std
@@ -14,3 +14,4 @@ Commands:
     {{#rpad length="23"}}{{@key}}{{/rpad}} {{.}}
 {{/each}}
 {{/condense}}
+


### PR DESCRIPTION
Without this newline, the template is rendered without a newline at the end. So when you run `grunt help cache`, the output does not have a newline at the end and the shell prompt will be printed at the end of the last line. It looks like this:

```
darabos@ramhegy:~$ bower help cache

Usage:

    bower cache <command> [<args>] [<options>]
Commands:

    clean                   Clean cached packages
    list                    List cached packagesdarabos@ramhegy:~$ 
```

This patch is the simplest fix (I tried it and it works). But another option is to trim the output in `util/template.js` and explicitly add one newline at the end. That would be less error prone -- how long before someone deletes this seemingly unnecessary newline? If you'd prefer that solution I can send a PR for that.

Thanks for Bower!
