### PR TITLE
option to skip console traces

### DIFF
--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -53,6 +53,7 @@ StandardRenderer.prototype.end = function (data) {
 StandardRenderer.prototype.error = function (err) {
     var str;
     var stack;
+    var printConsoleTraces = (this._config.printConsoleTraces !== false);
 
     this._guessOrigin(err);
 
@@ -75,11 +76,11 @@ StandardRenderer.prototype.error = function (err) {
         stack = err.fstream_stack || err.stack || 'N/A';
         str = chalk.yellow('\nStack trace:\n');
         str += (Array.isArray(stack) ? stack.join('\n') : stack) + '\n';
-        str += chalk.yellow('\nConsole trace:\n');
+        if (printConsoleTraces) { str += chalk.yellow('\nConsole trace:\n'); }
         /*jshint camelcase:true*/
 
         this._write(process.stderr, str);
-        console.trace();
+        if (printConsoleTraces) { console.trace(); }
 
         // Print bower version, node version and system info.
         this._write(process.stderr, chalk.yellow('\nSystem info:\n'));


### PR DESCRIPTION
In your bowerrc, set `{ "print-console-traces": false }` to skip them.
