### PR TITLE
Rename 'Prefix' to 'Suffix' in resolution message

### DIFF
--- a/templates/std/conflict.std
+++ b/templates/std/conflict.std
@@ -6,5 +6,5 @@
 {{/condense}}
 {{#unless saveResolutions}}
 
-Prefix the choice with ! to persist it to bower.json
+Suffix the choice with ! to persist it to bower.json
 {{/unless}}


### PR DESCRIPTION
The exclamation mark should actually be placed after the desired version, not before.
"Suffix" is the proper word for it, not "Prefix"
