### PR TITLE
Remove erroneous colon.

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -775,7 +775,7 @@ Manager.prototype._electSuitable = function (name, semvers, nonSemvers) {
     choices = picks.map(function (pick, index) { return index + 1; });
     return Q.nfcall(this._logger.prompt.bind(this._logger), {
         type: 'input',
-        message: 'Answer:',
+        message: 'Answer',
         validate: function (choice) {
             choice = Number(mout.string.trim(choice.trim(), '!'));
 


### PR DESCRIPTION
This only shows up with dependency conflicts arise, but it had two colons.

From this:

```
? Answer:: 
```

To this:

```
? Answer:
```

Steps to reproduce:

* Try to install two conflicting module versions.

Should affect all platforms.

Let me know if there's anything else that is needed. 