### PR TITLE
New bower list output

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -5,6 +5,7 @@ var Project = require('../core/Project');
 var semver = require('../util/semver');
 var cli = require('../util/cli');
 var defaultConfig = require('../config');
+var createError = require('../util/createError');
 
 function list(logger, options, config) {
     var project;
@@ -52,6 +53,9 @@ function list(logger, options, config) {
         });
 
         // Render paths?
+        if (options.sortedPaths) {
+            return sortedPaths(tree, config.cwd);
+        }
         if (options.paths) {
             return paths(flattened);
         }
@@ -109,6 +113,87 @@ function checkVersions(project, tree, logger) {
     return Q.all(promises);
 }
 
+function rememberPackage(packageName, packageMain, knownDependencyMap, packageList) {
+    var knownDependency = knownDependencyMap[packageName];
+    if (knownDependency && !knownDependency.resolving) {
+        // it's possible to hit the same dependency multiple times and as long as they're
+        // not resolving, we should return the known dependency so moot.array.difference works
+        packageMain = knownDependency.main;
+    } else {
+        knownDependencyMap[packageName] = {
+            main: packageMain
+        };
+        packageList.push(packageMain);
+    }
+    return packageMain;
+}
+
+function getSimpleDependency(pkgName, knownDependencyMap) {
+    var knownDependency = knownDependencyMap[pkgName];
+    if (knownDependency && knownDependency.resolving) {
+        // we've tried to resolve a dependency that we're still trying to find it's leaf for
+        // that means circular dependency and we can't flatten the tree
+        throw createError('Circular Dependency Found!');
+    }
+    return knownDependency;
+}
+
+function markPackageResolving(knownDependencyMap, packageName) {
+    knownDependencyMap[packageName] = {
+        resolving: true
+    };
+}
+
+function findInsertionLevel(dependencyQueue, simpleDependencies) {
+    for (var i = 0; i < dependencyQueue.length; i += 1) {
+        if (!simpleDependencies.length) {
+            return dependencyQueue[i];
+        }
+        // filter out the known dependencies at this level to find right insertion point
+        simpleDependencies = mout.array.difference(simpleDependencies, dependencyQueue[i]);
+    }
+    return dependencyQueue[dependencyQueue.length] = [];
+}
+
+function insertPackage(dependencyQueue, bowerPkg, knownDependencyMap, cwd) {
+    if (!bowerPkg || !bowerPkg.endpoint) {
+        return;
+    }
+    markPackageResolving(knownDependencyMap, bowerPkg.endpoint.name); // mark package as resolving to detect circular dependencies
+    var packagePath = normalizePaths(bowerPkg.pkgMeta && bowerPkg.pkgMeta.main, path.relative(cwd, bowerPkg.canonicalDir)),
+        simpleDependencies = Object.keys(bowerPkg.pkgMeta.dependencies || {}).map(function(pkgName) {
+            // process leafs of tree first
+            return getSimpleDependency(pkgName, knownDependencyMap) || insertPackage(dependencyQueue, bowerPkg.dependencies[pkgName], knownDependencyMap, cwd);
+        }).filter(function(item) {
+            return item; // remove nulls
+        }),
+        insertionLevel = findInsertionLevel(dependencyQueue, simpleDependencies);
+
+    return rememberPackage(bowerPkg.endpoint.name, packagePath, knownDependencyMap, insertionLevel);
+}
+
+function sortedPaths(tree, cwd) {
+    var knownDeps = {},
+        results = Object.keys(tree.dependencies).reduce(function(dependencyQueue, dependencyName){
+            insertPackage(dependencyQueue, tree.dependencies[dependencyName], knownDeps, cwd);
+            return dependencyQueue;
+          }, []);
+    return mout.array.flatten(results);
+}
+
+function normalizePaths(filepath, canonicalDir) {
+    if (!filepath) {
+        return [];
+    }
+    if (typeof filepath === 'string') {
+        filepath = [filepath];
+    }
+    // Concatenate each main entry with the canonical dir
+    return filepath.map(function(part) {
+        return normalize(path.join(canonicalDir, part).trim());
+    });
+}
+
 function paths(flattened) {
     var ret = {};
 
@@ -126,16 +211,7 @@ function paths(flattened) {
             ret[name] = pkg.canonicalDir;
             return;
         }
-
-        // Normalize main
-        if (typeof main === 'string') {
-            main = [main];
-        }
-
-        // Concatenate each main entry with the canonical dir
-        main = main.map(function (part) {
-            return normalize(path.join(pkg.canonicalDir, part).trim());
-        });
+        main = normalizePaths(main, pkg.canonicalDir);
 
         // If only one main file, use a string
         // Otherwise use an array
@@ -159,6 +235,7 @@ list.line = function (logger, argv) {
 list.options = function (argv) {
     return cli.readOptions({
         'paths': { type: Boolean, shorthand: 'p' },
+        'sorted-paths': { type: Boolean },
         'relative': { type: Boolean, shorthand: 'r' }
     }, argv);
 };

--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -178,6 +178,8 @@ StandardRenderer.prototype._list = function (tree) {
     if (tree.pkgMeta) {
         tree.root = true;
         cliTree = archy(this._tree2archy(tree));
+    } else if (tree instanceof Array) {
+        cliTree = tree.join('\n') + '\n';
     } else {
         cliTree = stringifyObject(tree, { indent: '  ' }).replace(/[{}]/g, '') + '\n';
     }

--- a/templates/json/help-list.json
+++ b/templates/json/help-list.json
@@ -16,6 +16,10 @@
             "description": "Generates a simple JSON source mapping"
         },
         {
+            "flag":        "--sorted-paths",
+            "description": "Outputs an array of source paths in dependency loading order"
+        },
+        {
             "shorthand":   "-r",
             "flag":        "--relative",
             "description": "Make paths relative to the directory config property, which defaults to bower_components"

--- a/test/commands/list.js
+++ b/test/commands/list.js
@@ -1,5 +1,6 @@
 var expect = require('expect.js');
 var object = require('mout').object;
+var Q = require('q');
 
 var helpers = require('../helpers');
 var commands = helpers.require('lib/index').commands;
@@ -33,162 +34,55 @@ describe('bower list', function () {
     };
 
     var list = function(options, config) {
-        var logger = listLogger(options, config);
+        var logger = listLogger(options, config),
+            deferred = Q.defer();
 
-        return helpers.expectEvent(logger, 'end');
+        logger.once('end', function () {
+            deferred.resolve(arguments);
+        });
+        logger.once('error', function () {
+            deferred.reject(arguments);
+        });
+
+        return deferred.promise;
     };
 
-    it('lists no packages when nothing installed', function () {
-        tempDir.prepare();
+    describe('default options', function(){
+        it('lists no packages when nothing installed', function () {
+            tempDir.prepare();
 
-        return list().then(function(args) {
-            var results = args[0];
-            expect(args.length).to.equal(1);
-            expect(results).to.be.an(Object);
-            expect(results.canonicalDir).to.equal(tempDir.path);
-            expect(results.pkgMeta.dependencies).to.eql({});
-            expect(results.pkgMeta.devDependencies).to.eql({});
-            expect(results.dependencies).to.eql({});
-            expect(results.nrDependants).to.eql(0);
-            expect(results.versions).to.eql([]);
-        });
-    });
-
-    it('lists 1 dependency when 1 local package installed', function () {
-
-        var package = new helpers.TempDir({
-            'bower.json': {
-                name: 'package',
-                main: 'test.txt'
-            }
-        }).prepare();
-        package.prepare();
-
-        return install([package.path]).then(function() {
             return list().then(function(args) {
                 var results = args[0];
                 expect(args.length).to.equal(1);
                 expect(results).to.be.an(Object);
                 expect(results.canonicalDir).to.equal(tempDir.path);
-                expect(results.pkgMeta.dependencies).to.eql({
-                    package: package.path + '#*'
-                });
+                expect(results.pkgMeta.dependencies).to.eql({});
                 expect(results.pkgMeta.devDependencies).to.eql({});
-                expect(results.dependencies.package).to.be.an(Object);
-                expect(results.dependencies.package.pkgMeta).to.be.an(Object);
-                expect(results.dependencies.package.pkgMeta.main).to.equal('test.txt');
-                expect(results.dependencies.package.canonicalDir).to.equal(tempDir.path + '/bower_components/package');
-                expect(results.dependencies.package.dependencies).to.eql({});
-                expect(results.dependencies.package.nrDependants).to.equal(1);
-                expect(results.dependencies.package.versions).to.eql([]);
-                expect(results.nrDependants).to.equal(0);
+                expect(results.dependencies).to.eql({});
+                expect(results.nrDependants).to.eql(0);
                 expect(results.versions).to.eql([]);
             });
         });
-    });
 
-    it('lists 1 dependency with relative paths when 1 local package installed', function () {
+        it('lists 1 dependency when 1 local package installed', function () {
+            tempDir.prepare();
 
-        var package = new helpers.TempDir({
-            'bower.json': {
-                name: 'package',
-                main: 'test.txt'
-            }
-        }).prepare();
-        package.prepare();
-
-        return install([package.path]).then(function() {
-            return list({relative: true}).then(function(args) {
-                var results = args[0];
-                expect(args.length).to.equal(1);
-                expect(results).to.be.an(Object);
-                expect(results.canonicalDir).to.equal(tempDir.path);
-                expect(results.dependencies).to.be.an(Object);
-                expect(results.dependencies.package).to.be.an(Object);
-                expect(results.dependencies.package.pkgMeta).to.be.an(Object);
-                expect(results.dependencies.package.pkgMeta.main).to.equal('test.txt');
-                expect(results.pkgMeta.dependencies).to.eql({
-                    package: package.path + '#*'
-                });
-                expect(results.dependencies.package.canonicalDir).to.equal('bower_components/package');
-            });
-        });
-    });
-
-    it('lists 1 dependency with 1 source relative source mapping when 1 local package installed', function () {
-
-        var package = new helpers.TempDir({
-            'bower.json': {
-                name: 'package',
-                main: 'test.txt'
-            }
-        }).prepare();
-        package.prepare();
-
-        return install([package.path]).then(function() {
-            return list({paths: true}).then(function(args) {
-                var results = args[0];
-                expect(args.length).to.equal(1);
-                expect(results).to.be.an(Object);
-                expect(results.package).to.equal('bower_components/package/test.txt');
-            });
-        });
-    });
-
-    it('lists 1 dependency with 2 source relative source mapping when 1 local package installed', function () {
-
-        var package = new helpers.TempDir({
-            'bower.json': {
-                name: 'package',
-                main: ['test.txt', 'test2.txt']
-            }
-        }).prepare();
-        package.prepare();
-
-        return install([package.path]).then(function() {
-            return list({paths: true}).then(function(args) {
-                var results = args[0];
-                expect(args.length).to.equal(1);
-                expect(results).to.be.an(Object);
-                expect(results.package).to.be.an(Object);
-                expect(results.package).to.eql(['bower_components/package/test.txt', 'bower_components/package/test2.txt']);
-            });
-        });
-    });
-
-    it('lists 1 dependency when 1 git package installed', function () {
-        return gitPackage.prepareGit({
-            '1.0.0': {
+            var package = new helpers.TempDir({
                 'bower.json': {
                     name: 'package',
                     main: 'test.txt'
-                },
-                'version.txt': '1.0.0'
-            },
-            '1.0.1': {
-                'bower.json': {
-                    name: 'package',
-                    main: 'test2.txt'
-                },
-                'version.txt': '1.0.1'
-            }
-        }).then(function() {
-            tempDir.prepare({
-                'bower.json': {
-                    name: 'test',
-                    dependencies: {
-                        package: gitPackage.path + '#1.0.0'
-                    }
                 }
             });
-            return install().then(function() {
+            package.prepare();
+
+            return install([package.path]).then(function() {
                 return list().then(function(args) {
                     var results = args[0];
                     expect(args.length).to.equal(1);
                     expect(results).to.be.an(Object);
                     expect(results.canonicalDir).to.equal(tempDir.path);
                     expect(results.pkgMeta.dependencies).to.eql({
-                        package: gitPackage.path + '#1.0.0'
+                        package: package.path + '#*'
                     });
                     expect(results.pkgMeta.devDependencies).to.eql({});
                     expect(results.dependencies.package).to.be.an(Object);
@@ -197,48 +91,318 @@ describe('bower list', function () {
                     expect(results.dependencies.package.canonicalDir).to.equal(tempDir.path + '/bower_components/package');
                     expect(results.dependencies.package.dependencies).to.eql({});
                     expect(results.dependencies.package.nrDependants).to.equal(1);
-                    expect(results.dependencies.package.versions).to.eql(['1.0.1', '1.0.0']);
+                    expect(results.dependencies.package.versions).to.eql([]);
                     expect(results.nrDependants).to.equal(0);
                     expect(results.versions).to.eql([]);
                 });
             });
         });
+
+        it('lists 1 dependency when 1 git package installed', function () {
+            tempDir.prepare();
+            return gitPackage.prepareGit({
+                '1.0.0': {
+                    'bower.json': {
+                        name: 'package',
+                        main: 'test.txt'
+                    },
+                    'version.txt': '1.0.0'
+                },
+                '1.0.1': {
+                    'bower.json': {
+                        name: 'package',
+                        main: 'test2.txt'
+                    },
+                    'version.txt': '1.0.1'
+                }
+            }).then(function() {
+                tempDir.prepare({
+                    'bower.json': {
+                        name: 'test',
+                        dependencies: {
+                            package: gitPackage.path + '#1.0.0'
+                        }
+                    }
+                });
+                return install().then(function() {
+                    return list().then(function(args) {
+                        var results = args[0];
+                        expect(args.length).to.equal(1);
+                        expect(results).to.be.an(Object);
+                        expect(results.canonicalDir).to.equal(tempDir.path);
+                        expect(results.pkgMeta.dependencies).to.eql({
+                            package: gitPackage.path + '#1.0.0'
+                        });
+                        expect(results.pkgMeta.devDependencies).to.eql({});
+                        expect(results.dependencies.package).to.be.an(Object);
+                        expect(results.dependencies.package.pkgMeta).to.be.an(Object);
+                        expect(results.dependencies.package.pkgMeta.main).to.equal('test.txt');
+                        expect(results.dependencies.package.canonicalDir).to.equal(tempDir.path + '/bower_components/package');
+                        expect(results.dependencies.package.dependencies).to.eql({});
+                        expect(results.dependencies.package.nrDependants).to.equal(1);
+                        expect(results.dependencies.package.versions).to.eql(['1.0.1', '1.0.0']);
+                        expect(results.nrDependants).to.equal(0);
+                        expect(results.versions).to.eql([]);
+                    });
+                });
+            });
+        });
     });
 
-    it('lists 1 dependency with relative paths when 1 git package installed', function () {
-        return gitPackage.prepareGit({
-            '1.0.0': {
+    describe('--paths', function(){
+        it('lists 1 dependency with relative paths when 1 local package installed', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
                 'bower.json': {
                     name: 'package',
                     main: 'test.txt'
-                },
-                'version.txt': '1.0.0'
-            },
-            '1.0.1': {
+                }
+            });
+            package.prepare();
+
+            return install([package.path]).then(function() {
+                return list({relative: true}).then(function(args) {
+                    var results = args[0];
+                    expect(args.length).to.equal(1);
+                    expect(results).to.be.an(Object);
+                    expect(results.canonicalDir).to.equal(tempDir.path);
+                    expect(results.dependencies).to.be.an(Object);
+                    expect(results.dependencies.package).to.be.an(Object);
+                    expect(results.dependencies.package.pkgMeta).to.be.an(Object);
+                    expect(results.dependencies.package.pkgMeta.main).to.equal('test.txt');
+                    expect(results.pkgMeta.dependencies).to.eql({
+                        package: package.path + '#*'
+                    });
+                    expect(results.dependencies.package.canonicalDir).to.equal('bower_components/package');
+                });
+            });
+        });
+
+        it('lists 1 dependency with 1 source relative source mapping when 1 local package installed', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
                 'bower.json': {
                     name: 'package',
-                    main: 'test2.txt'
+                    main: 'test.txt'
+                }
+            });
+            package.prepare();
+
+            return install([package.path]).then(function() {
+                return list({paths: true}).then(function(args) {
+                    var results = args[0];
+                    expect(args.length).to.equal(1);
+                    expect(results).to.be.an(Object);
+                    expect(results.package).to.equal('bower_components/package/test.txt');
+                });
+            });
+        });
+
+        it('lists 1 dependency with 2 source relative source mapping when 1 local package installed', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package',
+                    main: ['test.txt', 'test2.txt']
+                }
+            });
+            package.prepare();
+
+            return install([package.path]).then(function() {
+                return list({paths: true}).then(function(args) {
+                    var results = args[0];
+                    expect(args.length).to.equal(1);
+                    expect(results).to.be.an(Object);
+                    expect(results.package).to.be.an(Object);
+                    expect(results.package).to.eql(['bower_components/package/test.txt', 'bower_components/package/test2.txt']);
+                });
+            });
+        });
+
+        it('lists 1 dependency with relative paths when 1 git package installed', function () {
+            tempDir.prepare();
+            return gitPackage.prepareGit({
+                '1.0.0': {
+                    'bower.json': {
+                        name: 'package',
+                        main: 'test.txt'
+                    },
+                    'version.txt': '1.0.0'
                 },
-                'version.txt': '1.0.1'
-            }
-        }).then(function() {
+                '1.0.1': {
+                    'bower.json': {
+                        name: 'package',
+                        main: 'test2.txt'
+                    },
+                    'version.txt': '1.0.1'
+                }
+            }).then(function() {
+                tempDir.prepare({
+                    'bower.json': {
+                        name: 'test',
+                        dependencies: {
+                            package: gitPackage.path + '#1.0.0'
+                        }
+                    }
+                });
+                return install().then(function() {
+                    return list({relative: true}).then(function(args) {
+                        var results = args[0];
+                        expect(args.length).to.equal(1);
+                        expect(results.canonicalDir).to.equal(tempDir.path);
+                        expect(results.pkgMeta.dependencies).to.eql({
+                            package: gitPackage.path + '#1.0.0'
+                        });
+                        expect(results.dependencies.package.canonicalDir).to.equal('bower_components/package');
+                    });
+                });
+            });
+        });
+    });
+
+    describe('--sorted-paths', function(){
+        it('lists 1 file when 1 installed package has 1 file listed in main', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package',
+                    main: 'test.txt'
+                }
+            });
+            package.prepare();
+
+            return install([package.path]).then(function() {
+                return list({sortedPaths: true}).then(function(args) {
+                    var results = args[0];
+                    expect(args.length).to.equal(1);
+                    expect(results).to.be.an(Array);
+                    expect(results).to.eql(['bower_components/package/test.txt']);
+                });
+            });
+        });
+
+        it('lists 2 files when 1 installed package has 2 file listed in main', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package',
+                    main: ['test.txt', 'test2.txt']
+                }
+            });
+            package.prepare();
+
+            return install([package.path]).then(function() {
+                return list({sortedPaths: true}).then(function(args) {
+                    var results = args[0];
+                    expect(args.length).to.equal(1);
+                    expect(results).to.be.an(Array);
+                    expect(results).to.eql(['bower_components/package/test.txt', 'bower_components/package/test2.txt']);
+                });
+            });
+        });
+        it('lists 2 files in order when 1 installed package depends on another package', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package',
+                    main: 'test.txt'
+                }
+            });
+            package.prepare();
+            var package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2',
+                    main: 'test2.txt',
+                    dependencies: {
+                        package: package.path
+                    }
+                }
+            });
+            package2.prepare();
+
+            return install([package2.path]).then(function() {
+                return list({sortedPaths: true}).then(function(args) {
+                    var results = args[0];
+                    expect(args.length).to.equal(1);
+                    expect(results).to.be.an(Array);
+                    expect(results).to.eql(['bower_components/package/test.txt', 'bower_components/package2/test2.txt']);
+                });
+            });
+        });
+        it('errors out when a circular dependency is detected', function () {
+            var package = new helpers.TempDir();
+            var package2 = new helpers.TempDir();
             tempDir.prepare({
                 'bower.json': {
-                    name: 'test',
+                    name: 'root',
+                    main: 'test.txt',
                     dependencies: {
-                        package: gitPackage.path + '#1.0.0'
+                        package: package.path
+                    }
+                }
+            });
+            package.prepare({
+                'bower.json': {
+                    name: 'package',
+                    main: 'test.txt',
+                    dependencies: {
+                        package2: package2.path
+                    }
+                }
+            });
+            package2.prepare({
+                'bower.json': {
+                    name: 'package2',
+                    main: 'test2.txt',
+                    dependencies: {
+                        package: package.path
                     }
                 }
             });
             return install().then(function() {
-                return list({relative: true}).then(function(args) {
+                return list({sortedPaths: true}).then(function() {
+                    expect().fail('list should error out when circular dependencies are found');
+                }, function(){
+                    expect(1).to.be(1); // it should error out
+                });
+            });
+        });
+        it('lists 3 files in order when 1 installed package contains nested dependencies', function () {
+            tempDir.prepare();
+            var package = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package',
+                    main: 'test.txt'
+                }
+            });
+            package.prepare();
+            var package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2',
+                    main: 'test2.txt',
+                    dependencies: {
+                        package: package.path
+                    }
+                }
+            });
+            package2.prepare();
+            var package3 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package3',
+                    main: 'test3.txt',
+                    dependencies: {
+                        package2: package2.path
+                    }
+                }
+            });
+            package3.prepare();
+
+            return install([package3.path]).then(function() {
+                return list({sortedPaths: true}).then(function(args) {
                     var results = args[0];
                     expect(args.length).to.equal(1);
-                    expect(results.canonicalDir).to.equal(tempDir.path);
-                    expect(results.pkgMeta.dependencies).to.eql({
-                        package: gitPackage.path + '#1.0.0'
-                    });
-                    expect(results.dependencies.package.canonicalDir).to.equal('bower_components/package');
+                    expect(results).to.be.an(Array);
+                    expect(results).to.eql(['bower_components/package/test.txt', 'bower_components/package2/test2.txt', 'bower_components/package3/test3.txt']);
                 });
             });
         });


### PR DESCRIPTION
This is an updated version of pull request #1621 including new support for detecting circular dependencies as well as adding in Array detection to the list standard renderer.

This adds a new --sorted-paths array output to bower list api/commands. This will output all the main.js files in sorted order so that files are listed before they are depended on by other files. This is incredibly useful in determining load order of js files for a web page.

Unit tests added for new functionality (I also organized the existing list tests into groupings by options)