### PR TITLE
Fix for #1639, missing line break in CLI input

### DIFF
--- a/templates/std/conflict.std
+++ b/templates/std/conflict.std
@@ -4,6 +4,7 @@
     {{#magenta}}{{sum @index 1}}){{/magenta}} {{#cyan}}{{endpoint.name}}#{{endpoint.target}}{{/cyan}}{{#if pkgMeta._release}} which resolved to {{#green}}{{pkgMeta._release}}{{/green}}{{/if}}{{#if dependants}} and is required by {{#green}}{{dependants}}{{/green}} {{/if}}
 {{/each}}
 {{/condense}}
+
 {{#unless saveResolutions}}
 
 Prefix the choice with ! to persist it to bower.json


### PR DESCRIPTION
Adding new line to prefix notice, see #1639