### PR TITLE
Add --save-exact flag

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -35,7 +35,8 @@ install.readOptions = function (argv) {
         'force-latest': { type: Boolean, shorthand: 'F'},
         'production': { type: Boolean, shorthand: 'p' },
         'save': { type: Boolean, shorthand: 'S' },
-        'save-dev': { type: Boolean, shorthand: 'D' }
+        'save-dev': { type: Boolean, shorthand: 'D' },
+        'save-exact': { type: Boolean, shorthand: 'E' }
     }, argv);
 
     var packages = options.argv.remain.slice(1);

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -93,6 +93,10 @@ Project.prototype.install = function (decEndpoints, options, config) {
 
                 jsonEndpoint = endpointParser.decomposed2json(decEndpoint);
 
+                if (that._options.saveExact) {
+                    jsonEndpoint[decEndpoint.name] = decEndpoint.pkgMeta.version;
+                }
+
                 if (that._options.save) {
                     that._json.dependencies = mout.object.mixIn(that._json.dependencies || {}, jsonEndpoint);
                 }

--- a/templates/json/help-install.json
+++ b/templates/json/help-install.json
@@ -30,6 +30,11 @@
             "shorthand":   "-D",
             "flag":        "--save-dev",
             "description": "Save installed packages into the project's bower.json devDependencies"
+        },
+        {
+            "shorthand":   "-E",
+            "flag":        "--save-exact",
+            "description": "Configure installed packages with an exact version rather than semver"
         }
     ]
 }

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -51,6 +51,62 @@ describe('bower install', function () {
         });
     });
 
+    it('writes an exact version number to dependencies in bower.json if --save --save-exact flags are used', function () {
+        package.prepare({
+            'bower.json': {
+                version: '1.2.3'
+            }
+        });
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test'
+            }
+        });
+
+        return install([package.path], { saveExact: true, save: true }).then(function() {
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal('1.2.3');
+        });
+    });
+
+    it('writes an exact version number to devDependencies in bower.json if --save-dev --save-exact flags are used', function () {
+        package.prepare({
+            'bower.json': {
+                version: '0.1.0'
+            }
+        });
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test'
+            }
+        });
+
+        return install([package.path], { saveExact: true, saveDev: true }).then(function() {
+            expect(tempDir.readJson('bower.json').devDependencies.package).to.equal('0.1.0');
+        });
+    });
+
+    
+    it('does not write to bower.json if only --save-exact flag is used', function() {
+        package.prepare({
+            'bower.json': {
+                version: '1.2.3'
+            }
+        });
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test'
+            }
+        });
+
+        return install([package.path], { saveExact: true }).then(function() {
+            expect(tempDir.read('bower.json')).to.not.contain('dependencies');
+            expect(tempDir.read('bower.json')).to.not.contain('devDependencies');
+        });
+    });
+
     it('reads .bowerrc from cwd', function () {
         package.prepare({ foo: 'bar' });
 


### PR DESCRIPTION
Addresses #1636 (behaves the same way npm does).

Currently no test, since the following doesn't work for some reason:

```javascript
    it('writes an exact version number to bower.json if --save --save-exact flags are used', function () {
        var versionPackage = package.prepare({ foo: 'bar', version: '1.2.3' });

        tempDir.prepare({
            'bower.json': {
                name: 'test'
            }
        });

        return install([versionPackage.path], { save: true, saveExact: true }).then(function() {
            expect(tempDir.read('bower.json').dependencies.foo).to.equal('1.2.3');
        });
    });
```
