### PR TITLE
Allow for `bower version --no-git-tag-version`.

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -15,19 +15,30 @@ function version(logger, versionArg, options, config) {
     config = defaultConfig(config);
     project = new Project(config, logger);
 
-    return bump(project, versionArg, options.message);
+    return bump(project, versionArg, options);
 }
 
-function bump(project, versionArg, message) {
+function bump(project, versionArg, options) {
     var cwd = project._config.cwd || process.cwd();
     var newVersion;
-    var doGitCommit = false;
+    var doGitCommit = true;
+    var promise;
 
-    return checkGit(cwd)
-    .then(function (hasGit) {
-        doGitCommit = hasGit;
-    })
-    .then(project.getJson.bind(project))
+    if (options.hasOwnProperty('gitTagVersion')) {
+        doGitCommit = options.gitTagVersion;
+    }
+
+    if (doGitCommit) {
+        promise = checkGit(cwd)
+        .then(function (hasGit) {
+            doGitCommit = hasGit;
+        })
+        .then(project.getJson.bind(project));
+    } else {
+        promise = project.getJson();
+    }
+
+    return promise
     .then(function (json) {
         newVersion = getNewVersion(json.version, versionArg);
         json.version = newVersion;
@@ -35,7 +46,7 @@ function bump(project, versionArg, message) {
     .then(project.saveJson.bind(project))
     .then(function () {
         if (doGitCommit) {
-            return gitCommitAndTag(cwd, newVersion, message);
+            return gitCommitAndTag(cwd, newVersion, options.message);
         }
     })
     .then(function () {
@@ -118,7 +129,8 @@ version.readOptions = function (argv) {
     var cli = require('../util/cli');
 
     var options = cli.readOptions({
-        'message': { type: String, shorthand: 'm'}
+        'message': { type: String, shorthand: 'm'},
+        'git-tag-version': { type: Boolean }
     }, argv);
 
     return [options.argv.remain[1], options];

--- a/test/commands/version.js
+++ b/test/commands/version.js
@@ -88,4 +88,22 @@ describe('bower list', function () {
 
         });
     });
+
+    it('bumps without committing or tagging', function() {
+        return gitPackage.prepareGit().then(function() {
+
+            return helpers.run(version, ['patch', { gitTagVersion: false}, { cwd: gitPackage.path }]).then(function() {
+                expect(gitPackage.readJson('bower.json').version).to.be('0.0.1');
+
+                return gitPackage.git('tag').spread(function(result) {
+                    expect(result).to.be('v0.0.0\n');
+
+                    return gitPackage.git('status', '-s').spread(function(result) {
+                        expect(result).to.be(' M bower.json\n');
+                    });
+                });
+            });
+
+        });
+    });
 });


### PR DESCRIPTION
This is really poorly documented in [npm](https://docs.npmjs.com/misc/config#git-tag-version), but it'd be nice to have the option to not tag when running `bower version`, a la `npm version --no-git-tag-version`. For any project with multiple manifests, I think it's nice to be able to have one commit and tag for a version bump.

The option isn't really all that descriptive since it's really more like `--no-git-commit`. `--no-git-tag-version` keeps it in step with npm though.