### PR TITLE
Speed up `bower install` by avoiding unnecessary web requests

### DIFF
--- a/lib/core/PackageRepository.js
+++ b/lib/core/PackageRepository.js
@@ -88,8 +88,19 @@ PackageRepository.prototype.fetch = function (decEndpoint) {
             }
 
             // Otherwise check for new contents
+            var target = resolver.getTarget();
             logger.action('validate', (pkgMeta._release ? pkgMeta._release + ' against ': '') +
-                                      resolver.getSource() + (resolver.getTarget() ? '#' + resolver.getTarget() : ''));
+                                      resolver.getSource() + ( target ? '#' + target : ''));
+
+            var canonicalDirVersion = canonicalDir.match(/\/[^\/]*$/)[0].slice(1);
+            //Don't issue a web request if package has is versioned and we have the last version cached
+            if (target && canonicalDirVersion === target ) {
+                var retValue = [canonicalDir, pkgMeta, isTargetable];
+                //Wrap it in a promise
+                var deferred = Q.defer();
+                deferred.resolve(retValue);
+                return deferred.promise;
+            }
 
             return resolver.hasNew(canonicalDir, pkgMeta)
             .then(function (hasNew) {

--- a/lib/core/PackageRepository.js
+++ b/lib/core/PackageRepository.js
@@ -93,11 +93,12 @@ PackageRepository.prototype.fetch = function (decEndpoint) {
             logger.action('validate', (pkgMeta._release ? pkgMeta._release + ' against ': '') +
                                       resolver.getSource() + ( target ? '#' + target : ''));
 
-            var canonicalDirVersion = canonicalDir.match(/\/[^\/]*$/)[0].slice(1);
+            var canonicalDirVersion = canonicalDir.match(/\/[^\/]*$/)[0].slice(1); //basename of canonicalDir
             //Don't issue a web request if the package is versioned and we have the last version cached
             //console.log(target);
             //console.log(canonicalDirVersion);
-            if (target && semver.satisfies(canonicalDirVersion, target)) {
+            //console.log(canonicalDir);
+            if (target && semver.valid(canonicalDirVersion) && semver.satisfies(canonicalDirVersion, target)) {
                 var retValue = [canonicalDir, pkgMeta, isTargetable];
                 //Wrap it in a promise
                 var deferred = Q.defer();

--- a/lib/core/PackageRepository.js
+++ b/lib/core/PackageRepository.js
@@ -4,6 +4,7 @@ var RegistryClient = require('bower-registry-client');
 var ResolveCache = require('./ResolveCache');
 var resolverFactory = require('./resolverFactory');
 var createError = require('../util/createError');
+var semver = require('semver');
 
 function PackageRepository(config, logger) {
     var registryOptions;
@@ -93,8 +94,10 @@ PackageRepository.prototype.fetch = function (decEndpoint) {
                                       resolver.getSource() + ( target ? '#' + target : ''));
 
             var canonicalDirVersion = canonicalDir.match(/\/[^\/]*$/)[0].slice(1);
-            //Don't issue a web request if package has is versioned and we have the last version cached
-            if (target && canonicalDirVersion === target ) {
+            //Don't issue a web request if the package is versioned and we have the last version cached
+            //console.log(target);
+            //console.log(canonicalDirVersion);
+            if (target && semver.satisfies(canonicalDirVersion, target)) {
                 var retValue = [canonicalDir, pkgMeta, isTargetable];
                 //Wrap it in a promise
                 var deferred = Q.defer();


### PR DESCRIPTION
Don't check the web when doing `bower install` if the requested package is versioned and a satisfying version exists in the cache.
