### PR TITLE
config.directory absolute path fix

### DIFF
--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -49,7 +49,7 @@ function linkTo(logger, name, localName, config) {
 
     localName = localName || name;
     src = path.join(config.storage.links, name);
-    dst = path.join(config.cwd, config.directory, localName);
+    dst = path.resolve(config.cwd, config.directory, localName);
 
     // Delete destination folder if any
     return Q.nfcall(rimraf, dst)

--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -111,7 +111,7 @@ Manager.prototype.resolve = function () {
 
 Manager.prototype.preinstall = function (json) {
     var that = this;
-    var componentsDir = path.join(this._config.cwd, this._config.directory);
+    var componentsDir = path.resolve(this._config.cwd, this._config.directory);
 
     // If nothing to install, skip the code bellow
     if (mout.lang.isEmpty(that._dissected)) {
@@ -128,7 +128,7 @@ Manager.prototype.preinstall = function (json) {
 
 Manager.prototype.postinstall = function (json) {
     var that = this;
-    var componentsDir = path.join(this._config.cwd, this._config.directory);
+    var componentsDir = path.resolve(this._config.cwd, this._config.directory);
 
     // If nothing to install, skip the code bellow
     if (mout.lang.isEmpty(that._dissected)) {
@@ -157,7 +157,7 @@ Manager.prototype.install = function (json) {
         return Q.resolve({});
     }
 
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = path.resolve(this._config.cwd, this._config.directory);
     return Q.nfcall(mkdirp, componentsDir)
     .then(function () {
         var promises = [];

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -590,7 +590,7 @@ Project.prototype._readInstalled = function () {
 
     // Gather all folders that are actual packages by
     // looking for the package metadata file
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = path.resolve(this._config.cwd, this._config.directory);
     return this._installed = Q.nfcall(glob, '*/.bower.json', {
         cwd: componentsDir,
         dot: true
@@ -631,7 +631,7 @@ Project.prototype._readLinks = function () {
     var that = this;
 
     // Read directory, looking for links
-    componentsDir = path.join(this._config.cwd, this._config.directory);
+    componentsDir = path.resolve(this._config.cwd, this._config.directory);
     return Q.nfcall(fs.readdir, componentsDir)
     .then(function (filenames) {
         var promises;


### PR DESCRIPTION
Hi all

Fix for this issue: https://github.com/bower/bower/issues/894
You can see some of my thoughts there in comments.

I've changed all `path.join()` to `path.resolve()` ([docs](http://nodejs.org/api/path.html#path_path_resolve_from_to))

With `path.resolve()` if `config.directory` starts with `/`, `config.cwd` will not be used.
