### PR TITLE
Pluggable resolvers

### DIFF
--- a/lib/core/PackageRepository.js
+++ b/lib/core/PackageRepository.js
@@ -117,7 +117,7 @@ PackageRepository.prototype.fetch = function (decEndpoint) {
 PackageRepository.prototype.versions = function (source) {
     // Resolve the source using the factory because the
     // source can actually be a registry name
-    return resolverFactory.getConstructor(source, this._config, this._registryClient)
+    return resolverFactory.getConstructor(source, this._config, this._registryClient, this._logger)
     .spread(function (ConcreteResolver, source) {
         // If offline, resolve using the cached versions
         if (this._config.offline) {

--- a/lib/core/resolverFactory.js
+++ b/lib/core/resolverFactory.js
@@ -6,28 +6,46 @@ var resolvers = require('./resolvers');
 var createError = require('../util/createError');
 
 function createInstance(decEndpoint, config, logger, registryClient) {
-    return getConstructor(decEndpoint.source, config, registryClient)
-    .spread(function (ConcreteResolver, source, fromRegistry) {
-        var decEndpointCopy = mout.object.pick(decEndpoint, ['name', 'target']);
+    return getConstructor(decEndpoint.source, config, registryClient, logger)
+        .spread(function (ConcreteResolver, source, fromRegistry) {
+            var decEndpointCopy = mout.object.pick(decEndpoint, ['name', 'target']);
 
-        decEndpointCopy.source = source;
+            decEndpointCopy.source = source;
 
-        // Signal if it was fetched from the registry
-        if (fromRegistry) {
-            decEndpoint.registry = true;
-            // If no name was specified, assume the name from the registry
-            if (!decEndpointCopy.name) {
-                decEndpointCopy.name = decEndpoint.name = decEndpoint.source;
+            // Signal if it was fetched from the registry
+            if (fromRegistry) {
+                decEndpoint.registry = true;
+                // If no name was specified, assume the name from the registry
+                if (!decEndpointCopy.name) {
+                    decEndpointCopy.name = decEndpoint.name = decEndpoint.source;
+                }
             }
-        }
 
-        return new ConcreteResolver(decEndpointCopy, config, logger);
-    });
+            return new ConcreteResolver(decEndpointCopy, config, logger);
+        });
 }
 
-function getConstructor(source, config, registryClient) {
-    var absolutePath,
-        promise;
+function getConstructor(source, config, registryClient, logger) {
+    var absolutePath;
+    var promise;
+    var resolverPrefix = extractRegistryPrefix(source);
+
+    if(resolverPrefix) {
+        try {
+            var pkgResolver = require('bower-' + resolverPrefix + '-resolver');
+
+            return Q.fcall(function () {
+                return [pkgResolver, source];
+            });
+        }
+         catch (err) {
+             // Could not found the relevant resolver package
+             // go to backward compatibility resolvers...
+             logger.debug('resolver-plugin', 'Could not found the relevant resolver node package!');
+        }
+    }
+    //go to backward compatibility resolvers...
+
 
     // Git case: git git+ssh, git+http, git+https
     //           .git at the end (probably ssh shorthand)
@@ -69,98 +87,98 @@ function getConstructor(source, config, registryClient) {
 
     if (/^\.\.?[\/\\]/.test(source) || /^~\//.test(source) || path.normalize(source).replace(/[\/\\]+$/, '') === absolutePath) {
         promise = Q.nfcall(fs.stat, path.join(absolutePath, '.git'))
-        .then(function (stats) {
-            if (stats.isDirectory()) {
-                return function () {
-                    return Q.resolve([resolvers.GitFs, absolutePath]);
-                };
-            }
-
-            throw new Error('Not a Git repository');
-        })
-        // If not, check if source is a valid Subversion repository
-        .fail(function () {
-            return Q.nfcall(fs.stat, path.join(absolutePath, '.svn'))
             .then(function (stats) {
                 if (stats.isDirectory()) {
                     return function () {
-                        return Q.resolve([resolvers.Svn, absolutePath]);
+                        return Q.resolve([resolvers.GitFs, absolutePath]);
                     };
                 }
 
-                throw new Error('Not a Subversion repository');
+                throw new Error('Not a Git repository');
+            })
+            // If not, check if source is a valid Subversion repository
+            .fail(function () {
+                return Q.nfcall(fs.stat, path.join(absolutePath, '.svn'))
+                    .then(function (stats) {
+                        if (stats.isDirectory()) {
+                            return function () {
+                                return Q.resolve([resolvers.Svn, absolutePath]);
+                            };
+                        }
+
+                        throw new Error('Not a Subversion repository');
+                    });
+            })
+            // If not, check if source is a valid file/folder
+            .fail(function () {
+                return Q.nfcall(fs.stat, absolutePath)
+                    .then(function () {
+                        return function () {
+                            return Q.resolve([resolvers.Fs, absolutePath]);
+                        };
+                    });
             });
-        })
-        // If not, check if source is a valid file/folder
-        .fail(function () {
-            return Q.nfcall(fs.stat, absolutePath)
-            .then(function () {
-                return function () {
-                    return Q.resolve([resolvers.Fs, absolutePath]);
-                };
-            });
-        });
     } else {
         promise = Q.reject(new Error('Not an absolute or relative file'));
     }
 
     return promise
-    // Check if is a shorthand and expand it
-    .fail(function (err) {
-        var parts;
+        // Check if is a shorthand and expand it
+        .fail(function (err) {
+            var parts;
 
-        // Skip ssh and/or URL with auth
-        if (/[:@]/.test(source)) {
+            // Skip ssh and/or URL with auth
+            if (/[:@]/.test(source)) {
+                throw err;
+            }
+
+            // Ensure exactly only one "/"
+            parts = source.split('/');
+            if (parts.length === 2) {
+                source = mout.string.interpolate(config.shorthandResolver, {
+                    shorthand: source,
+                    owner: parts[0],
+                    package: parts[1]
+                });
+
+                return function () {
+                    return getConstructor(source, config, registryClient, logger);
+                };
+            }
+
             throw err;
-        }
-
-        // Ensure exactly only one "/"
-        parts = source.split('/');
-        if (parts.length === 2) {
-            source = mout.string.interpolate(config.shorthandResolver, {
-                shorthand: source,
-                owner: parts[0],
-                package: parts[1]
-            });
+        })
+        // As last resort, we try the registry
+        .fail(function (err) {
+            if (!registryClient) {
+                throw err;
+            }
 
             return function () {
-                return getConstructor(source, config, registryClient);
+                return Q.nfcall(registryClient.lookup.bind(registryClient), source)
+                    .then(function (entry) {
+                        if (!entry) {
+                            throw createError('Package ' + source + ' not found', 'ENOTFOUND');
+                        }
+
+                        // TODO: Handle entry.type.. for now it's only 'alias'
+                        //       When we got published packages, this needs to be adjusted
+                        source = entry.url;
+
+                        return getConstructor(source, config, registryClient, logger)
+                            .spread(function (ConcreteResolver, source) {
+                                return [ConcreteResolver, source, true];
+                            });
+                    });
             };
-        }
-
-        throw err;
-    })
-    // As last resort, we try the registry
-    .fail(function (err) {
-        if (!registryClient) {
-            throw err;
-        }
-
-        return function () {
-            return Q.nfcall(registryClient.lookup.bind(registryClient), source)
-            .then(function (entry) {
-                if (!entry) {
-                    throw createError('Package ' + source + ' not found', 'ENOTFOUND');
-                }
-
-                // TODO: Handle entry.type.. for now it's only 'alias'
-                //       When we got published packages, this needs to be adjusted
-                source = entry.url;
-
-                return getConstructor(source, config, registryClient)
-                .spread(function (ConcreteResolver, source) {
-                    return [ConcreteResolver, source, true];
-                });
-            });
-        };
-    })
-    // If we got the function, simply call and return
-    .then(function (func) {
-        return func();
-    // Finally throw a meaningful error
-    }, function () {
-        throw createError('Could not find appropriate resolver for ' + source, 'ENORESOLVER');
-    });
+        })
+        // If we got the function, simply call and return
+        .then(function (func) {
+            return func();
+            // Finally throw a meaningful error
+        }, function () {
+            throw createError('Could not find appropriate resolver for ' + source, 'ENORESOLVER');
+        });
 }
 
 function clearRuntimeCache() {
@@ -169,6 +187,21 @@ function clearRuntimeCache() {
     });
 }
 
+function extractRegistryPrefix(source){
+    var match;
+    if(!source){
+        return null;
+    }
+
+    match = source.split(':');
+    if (match.length < 2) {
+        return null;
+    }
+
+    return match[0];
+}
+
 module.exports = createInstance;
 module.exports.getConstructor = getConstructor;
 module.exports.clearRuntimeCache = clearRuntimeCache;
+module.exports.extractRegistryPrefix = extractRegistryPrefix;

--- a/lib/core/resolverFactory.js
+++ b/lib/core/resolverFactory.js
@@ -26,8 +26,6 @@ function createInstance(decEndpoint, config, logger, registryClient) {
 }
 
 function getConstructor(source, config, registryClient, logger) {
-    var absolutePath;
-    var promise;
     var resolverPrefix = extractRegistryPrefix(source);
 
     if(resolverPrefix) {
@@ -40,12 +38,19 @@ function getConstructor(source, config, registryClient, logger) {
         }
          catch (err) {
              // Could not found the relevant resolver package
-             // go to backward compatibility resolvers...
+             //backward compatibility - go to core resolvers...
              logger.debug('resolver-plugin', 'Could not found the relevant resolver node package!');
         }
     }
-    //go to backward compatibility resolvers...
 
+    //backward compatibility - go to core resolvers...
+    return findInCoreResolvers(source, config, registryClient, logger);
+
+}
+
+function findInCoreResolvers(source, config, registryClient, logger) {
+    var absolutePath;
+    var promise;
 
     // Git case: git git+ssh, git+http, git+https
     //           .git at the end (probably ssh shorthand)

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,8 @@ var abbrev = require('abbrev');
 var mout = require('mout');
 var commands = require('./commands');
 var pkg = require('../package.json');
+var util = require('./util');
+var resolverBase = require('./core/resolvers/Resolver');
 
 var abbreviations = abbrev(expandNames(commands));
 abbreviations.i = 'install';
@@ -39,5 +41,7 @@ module.exports = {
     commands: commands,
     config: require('./config')(),
     abbreviations: abbreviations,
-    reset: clearRuntimeCache
+    reset: clearRuntimeCache,
+    util: util,
+    resolverBase:resolverBase
 };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,0 +1,17 @@
+module.exports = {
+    analytics: require('./analytics'),
+    cli: require('./cli'),
+    cmd: require('./cmd'),
+    copy: require('./copy'),
+    createError: require('./createError'),
+    createLink: require('./createLink'),
+    download: require('./download'),
+    extract: require('./extract'),
+    md5: require('./md5'),
+    readJson: require('./readJson'),
+    removeIgnores: require('./removeIgnores'),
+    rootCheck: require('./rootCheck'),
+    semver: require('./semver'),
+    template: require('./template'),
+    validLink: require('./validLink')
+};

--- a/test/assets/bower-test-resolver/lib/index.js
+++ b/test/assets/bower-test-resolver/lib/index.js
@@ -1,0 +1,12 @@
+var util = require('util');
+var mout = require('mout');
+var Resolver = require('../../../../lib/core/resolvers/resolver');
+
+function TestResolver(decEndpoint, config, logger) {
+    Resolver.call(this, decEndpoint, config, logger);
+}
+
+util.inherits(TestResolver, Resolver);
+mout.object.mixIn(TestResolver, Resolver);
+
+module.exports = TestResolver;

--- a/test/assets/bower-test-resolver/lib/index.js
+++ b/test/assets/bower-test-resolver/lib/index.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var mout = require('mout');
-var Resolver = require('../../../../lib/core/resolvers/resolver');
+var Resolver = require('../../../../lib/core/resolvers/Resolver');
 
 function TestResolver(decEndpoint, config, logger) {
     Resolver.call(this, decEndpoint, config, logger);

--- a/test/assets/bower-test-resolver/package.json
+++ b/test/assets/bower-test-resolver/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bower-test-resolver",
+  "version": "0.9.0",
+  "description": "Test resolver for pluggable resolvers feature",
+  "main": "./lib/index.js",
+  "scripts": {
+    "start": "node ./bin/www"
+  },
+  "dependencies": {
+    "util":"*",
+    "mout":"*"
+  }
+}

--- a/test/core/resolverFactory.js
+++ b/test/core/resolverFactory.js
@@ -690,4 +690,22 @@ describe('resolverFactory', function () {
             expect(called.sort()).to.eql(Object.keys(resolvers).sort());
         });
     });
+
+    describe('.extractRegistryPrefix', function (){
+        it('Should know how to extract the registry prefix for resolver plugin', function (){
+            var resolverFactory = require('../../lib/core/resolverFactory');
+            var endpoints = {
+                'git': 'git://github.com/user/project/bleh.git',
+                'bitbucket': 'bitbucket:jquery/jquery'
+            };
+
+            mout.object.forOwn(endpoints, function (value, key) {
+                var prefix = resolverFactory.extractRegistryPrefix(value);
+                expect(prefix).to.eql(key);
+            });
+
+            var prefix = resolverFactory.extractRegistryPrefix('jquery');
+            expect(prefix).to.be(null);
+        });
+    });
 });

--- a/test/core/resolverFactory.js
+++ b/test/core/resolverFactory.js
@@ -559,6 +559,30 @@ describe('resolverFactory', function () {
         .done();
     });
 
+    it('should recognize the pluggable resolver', function(next){
+        var registryPrefix = 'test';
+        var sourceWithPrefix = registryPrefix +'://foo/foo';
+        var pluggableTestResolver = helpers.require('test/assets/bower-' + registryPrefix + '-resolver');
+
+        var resolverFactoryStub = function () {
+            return helpers.require('lib/core/resolverFactory', {
+                'bower-test-resolver': pluggableTestResolver
+            });
+        };
+
+        var resolverFactoryConstructor = resolverFactoryStub(function (){
+        }).getConstructor(sourceWithPrefix);
+
+        resolverFactoryConstructor
+            .spread(function (ConcreteResolver){
+                expect(new ConcreteResolver({ source: sourceWithPrefix })).to.be.a(pluggableTestResolver);
+            })
+            .then(function(){
+                next();
+            })
+            .done();
+    });
+
     it('should error out if the package was not found in the registry', function (next) {
         callFactory({ source: 'some-package-that-will-never-exist' })
         .then(function () {


### PR DESCRIPTION
Hi,

As the first step for pluggable resolvers in Bower (issue #1649), this pull request adds behavior to the resolver factory to support such external resolvers. 

External resolvers are implemented as independent npm packages, that contain the bower project in the **peerDependencies** defs. 
I have implemented an example resolver: https://github.com/liorhson/bower-arti-resolver.

Currently, the factory looks for an external resolver by using the prefix of the package source returned from the registry. In case the factory cannot find the resolver package, it falls back to using the old behavior, referring to one of the built-in resolvers.

For now, I left the built-in resolvers as they were, but of course they can be externalized.
This is just to get the ball rolling, so we can iterate around the code.

Cheers,