### PR TITLE
Re-adds a (reduced) Analytics section back to the Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ This command will output a Bash / ZSH script to put into your `~/.bashrc`,
 $ bower completion >> ~/.bash_profile
 ```
 
+## Analytics
+
+Bower can collect anonymous usage statistics. This allows the community to improve Bower and publicly display insights into CLI usage and packages at [stats.bower.io](http://stats.bower.io).
+
+Data is tracked using Google Analytics and instrumented via [Insight](https://github.com/yeoman/insight). It is made available to all bower team members. Tracking is opt-in upon initial usage. If you'd prefer to disable analytics altogether, you can manually opt-out, set the `analytics` options in [the `.bowerrc` configuration](http://bower.io/docs/config/#analytics), set a `CI` environment variable , or run `bower install` with the `--config.interactive=false` option.
+
 
 ## Support
 


### PR DESCRIPTION
Adds details for disabling analytics for (for example) non-interactive build scripts and the like.

I'm a first-time user, and it took reading https://github.com/bower/bower/issues/1102 to discover how to run Bower <s>on fresh CI setups</s> without the prompt appearing. As far as I can tell, the `CI` env and `--config.interactive=false` command-line options aren't documented.

(Analytics section added by @benschwarz in https://github.com/bower/bower/pull/1277, then removed by @rayshan in https://github.com/bower/bower/pull/1473.)