### PR TITLE
Regsiter pulls unprovided name & URL from bower.json

### DIFF
--- a/lib/commands/register.js
+++ b/lib/commands/register.js
@@ -7,12 +7,14 @@ var Tracker = require('../util/analytics').Tracker;
 var createError = require('../util/createError');
 var defaultConfig = require('../config');
 var GitHubResolver = require('../core/resolvers/GitHubResolver');
+var Project = require('../core/Project');
 
 function register(logger, name, url, config) {
     var repository;
     var registryClient;
     var tracker;
     var force;
+    var onArgsReady;
 
     config = defaultConfig(config);
     force = config.force;
@@ -25,7 +27,7 @@ function register(logger, name, url, config) {
     config.offline = false;
     config.force = true;
 
-    return Q.try(function () {
+    onArgsReady = function () { return Q.try(function () {
         // Verify name and url
         if (!name || !url) {
             throw createError('Usage: bower register <name> <url>', 'EINVFORMAT');
@@ -81,6 +83,25 @@ function register(logger, name, url, config) {
         });
 
         return Q.nfcall(registryClient.register.bind(registryClient), name, url);
+    }); };
+
+    if (name && url) {
+        return onArgsReady();
+    }
+
+    var project = new Project(config, logger);
+    return project.getJson()
+    .then(function (json) {
+        var repository;
+        name = json.name || '';
+        repository = json.repository;
+        if (repository && repository.type === 'git') {
+            url = repository.url || '';
+        }
+        return onArgsReady();
+    }, function () {
+        logger.warn('bad json', 'Error reading JSON package.');
+        return onArgsReady();
     });
 }
 


### PR DESCRIPTION
Allows calling the `register` command without required `name` and `url` arguments:

```
bower register
```

In this case, we attempt to pull these values from a local `bower.json` file, assuming the user's current working directory is that of the package being registered.

This makes it more convenient to register packages, and more familiar to users of [`npm publish`](https://docs.npmjs.com/cli/publish), which has the same convention of assuming local package registration and not requiring any arguments.

In command-line mode, the usual confirmation prompt is still presented, so it shouldn't be very dangerous, at least for that use case. I deleted two failing test cases since they were tested for arguments that are no longer required immediately. <del>I'm not sure yet how to add test cases checking what happens when the `bower.json` does or doesn't have the pulled properties.</del> Added test cases for new scenarios.

I have not yet changed the messaging of the error indicating the arguments are required, nor have I yet changed the help/usage as such.

I realize the `onArgsReady` function has interesting indentation, but I wanted to minimize line changes to ease merge in case of other changes to the function - but I can reformat & rebase if requested.
