### PR TITLE
expose mocha grep as optional grunt cli option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,8 @@ module.exports = function (grunt) {
         simplemocha: {
             options: {
                 reporter: 'spec',
-                timeout: '8000'
+                timeout: '8000',
+                grep: grunt.option('grep')
             },
             full: {
                 src: ['test/test.js']


### PR DESCRIPTION
This lets us run a subset of tests from the command-line, e.g.:

```
grunt test --mocha.grep="bower register"
```
