### PR TITLE
Add --skip-git flag to version

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -15,18 +15,23 @@ function version(logger, versionArg, options, config) {
     config = defaultConfig(config);
     project = new Project(config, logger);
 
-    return bump(project, versionArg, options.message);
+    return bump(project, versionArg, options.message, options.skipGit);
 }
 
-function bump(project, versionArg, message) {
+function bump(project, versionArg, message, skipGit) {
     var cwd = project._config.cwd || process.cwd();
     var newVersion;
     var doGitCommit = false;
 
-    return checkGit(cwd)
-    .then(function (hasGit) {
-        doGitCommit = hasGit;
-    })
+    var doCheckGit = Q.when();
+    if(!skipGit) {
+        doCheckGit = checkGit(cwd)
+        .then(function (hasGit) {
+            doGitCommit = hasGit;
+        });
+    }
+
+    return doCheckGit
     .then(project.getJson.bind(project))
     .then(function (json) {
         newVersion = getNewVersion(json.version, versionArg);
@@ -118,7 +123,8 @@ version.readOptions = function (argv) {
     var cli = require('../util/cli');
 
     var options = cli.readOptions({
-        'message': { type: String, shorthand: 'm'}
+        'message': { type: String, shorthand: 'm'},
+        'skip-git': { type: Boolean }
     }, argv);
 
     return [options.argv.remain[1], options];

--- a/templates/json/help-version.json
+++ b/templates/json/help-version.json
@@ -1,6 +1,6 @@
 {
     "command": "version",
-    "description": "Run this in a package directory to bump the version and write the new data back to the bower.json file.\n\nThe newversion argument should be a valid semver string, or a valid second argument to semver.inc (one of \"build\", \"patch\", \"minor\", or \"major\"). In the second case, the existing version will be incremented\nby 1 in the specified field.\n\nIf run in a git repo, it will also create a version commit and tag, and fail if the repo is not clean.\n\nIf supplied with --message (shorthand: -m) config option, bower will use it as a commit message when creating a version commit. If the message config contains %s then that will be replaced with the resulting\nversion number. For example:\n\n    bower version patch -m \"Upgrade to %s for reasons\"",
+    "description": "Run this in a package directory to bump the version and write the new data back to the bower.json file.\n\nThe newversion argument should be a valid semver string, or a valid second argument to semver.inc (one of \"build\", \"patch\", \"minor\", or \"major\"). In the second case, the existing version will be incremented\nby 1 in the specified field.\n\nIf run in a git repo, it will also create a version commit and tag, and fail if the repo is not clean unless the --skip-git flag is supplied, then bower won't try to create the commit and tag it.\n\nIf supplied with --message (shorthand: -m) config option, bower will use it as a commit message when creating a version commit. If the message config contains %s then that will be replaced with the resulting\nversion number. For example:\n\n    bower version patch -m \"Upgrade to %s for reasons\"",
     "usage": [
         "version [<newversion> | major | minor | patch]"
     ],
@@ -9,6 +9,10 @@
             "shorthand":   "-m",
             "flag":        "--message",
             "description": "Custom git commit and tag message"
+        },
+        {
+            "flag":        "--skip-git",
+            "description": "Skip all git operations, namely commiting bower.json and creating a version tag"
         }
     ]
 }

--- a/test/commands/version.js
+++ b/test/commands/version.js
@@ -88,4 +88,22 @@ describe('bower list', function () {
 
         });
     });
+
+    it('does not try commit when using the --skip-git flag', function() {
+         return gitPackage.prepareGit().then(function() {
+
+            return helpers.run(version, ['patch', { skipGit: true}, { cwd: gitPackage.path }]).then(function() {
+                expect(gitPackage.readJson('bower.json').version).to.be('0.0.1');
+
+                return gitPackage.git('tag').spread(function(result) {
+                    expect(result).to.be('v0.0.0\n');
+
+                    return gitPackage.git('log', '--pretty=format:%s', '-n1').spread(function(result) {
+                        expect(result).to.be('"commit"');
+                    });
+                });
+            });
+
+        });
+    });
 });


### PR DESCRIPTION
In order to make bower easier to integrate in different build chain, it would be practical to be able to use its semver features to update the `bower.json` without getting any git operations done.

The feature added is the `--skip-git` flag, that would remove from `bower version` any git related behaviour, namely:
+ checking if the current repository is a git repository, and failing if not.
+ committing the changed `bower.json` file.
+ tagging the commit.

All 464 already existing unit tests are running, and one was added for this specific feature.
Helper of the `version` command was updated but I think it needs review from a native english speaker.

Thanks!