### PR TITLE
Fixes #1754: The version command in the programmatic API now returns the new version

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -40,6 +40,7 @@ function bump(project, versionArg, message) {
     })
     .then(function () {
         console.log('v' + newVersion);
+        return newVersion;
     });
 }
 

--- a/test/commands/version.js
+++ b/test/commands/version.js
@@ -53,6 +53,14 @@ describe('bower list', function () {
         });
     });
 
+    it('returns the new version', function() {
+        package.prepare();
+
+        return helpers.run(version, ['major', {}, { cwd: package.path }]).then(function(results) {
+            expect(results[0]).to.be('1.0.0');
+        });
+    });
+
     it('bumps patch version, create commit, and tag', function() {
         return gitPackage.prepareGit().then(function() {
 


### PR DESCRIPTION
When users of the programmatic API update the version, they may do so without having to inspect the new contents of the bower.json file to find out the new version.

This is useful in scripts where the tag needs to be pushed programatically; the user can push the new tag explicitly.