### PR TITLE
Changed smart Git host detection

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -206,11 +206,14 @@ GitRemoteResolver.prototype._supportsShallowCloning = function () {
         })
         .spread(function (stdout, stderr) {
             // Check stderr for content-type, ignore stdout
-            var isSmartServer;
+            var isSmartServer = false;
 
-            // If the content type is 'x-git', then the server supports shallow cloning
-            isSmartServer = mout.string.contains(stderr,
-                'Content-Type: application/x-git-upload-pack-advertisement');
+            var contentTypes = stderr.match(/Content-Type\: (.*)/);
+
+            if (contentTypes) {
+                // If the response's first content type is 'x-git', then the server supports shallow cloning
+                isSmartServer = contentTypes[1] === 'application/x-git-upload-pack-advertisement';
+            }
 
             this._logger.debug('detect-smart-git', 'Smart Git host detected: ' + isSmartServer);
 

--- a/test/core/resolvers/gitRemoteResolver.js
+++ b/test/core/resolvers/gitRemoteResolver.js
@@ -336,6 +336,50 @@ describe('GitRemoteResolver', function () {
             });
         });
 
+        it('should evaluate to false when the smart content type is returned, but not in the first content type entry - text/plain', function (next) {
+            var testSource = 'https://foo/bar.git';
+
+            var MyGitRemoteResolver = gitRemoteResolverFactory(
+                createCmdHandlerFn(testSource, multiline(function () {/*
+                 < Date: Wed, 01 Apr 2015 17:15:56 GMT
+                 < Content-Type: text/plain
+                 < foo: bar
+                 < Content-Type: application/x-git-upload-pack-advertisement
+                 1234: 5678
+                 */}))
+            );
+
+            var resolver = new MyGitRemoteResolver({ source: testSource }, defaultConfig(), logger);
+
+            resolver._shallowClone().then(function (shallowCloningSupported) {
+                expect(shallowCloningSupported).to.be(false);
+
+                next();
+            });
+        });
+
+        it('should evaluate to false when the smart content type is returned, but not in the first content type entry - text/html', function (next) {
+            var testSource = 'https://foo/bar.git';
+
+            var MyGitRemoteResolver = gitRemoteResolverFactory(
+                createCmdHandlerFn(testSource, multiline(function () {/*
+                 < Date: Wed, 01 Apr 2015 17:15:56 GMT
+                 < Content-Type: text/html
+                 < foo: bar
+                 < Content-Type: application/x-git-upload-pack-advertisement
+                 1234: 5678
+                 */}))
+            );
+
+            var resolver = new MyGitRemoteResolver({ source: testSource }, defaultConfig(), logger);
+
+            resolver._shallowClone().then(function (shallowCloningSupported) {
+                expect(shallowCloningSupported).to.be(false);
+
+                next();
+            });
+        });
+
         it('should evaluate to true when the smart content type is returned', function (next) {
             var testSource = 'https://foo/bar.git';
 


### PR DESCRIPTION
Only check the first Content-Type returned by the server. Some hosts are
returning text/plain in the first response, and then the correct content
type in later responses. This seems to be the case for GitHub
Enterprise. By checking the first content type entry, we should be able
to verify this.

Also added unit tests to test this behavior.

This should hopefully fix #1764 for most people.