### PR TITLE
Update semver to >= 4.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "request-progress": "0.3.1",
     "retry": "0.6.1",
     "rimraf": "^2.2.8",
-    "semver": "^2.3.0",
+    "semver": "^4.3.3",
     "shell-quote": "^1.4.2",
     "stringify-object": "^1.0.0",
     "tar-fs": "^1.4.1",


### PR DESCRIPTION
Mitigates [semver Regular Expression Denial of Service](https://nodesecurity.io/advisories/semver_redos).

Automated build systems performing `nsp audit-package` on build are tripped by the vulnerable semver version used by bower.