### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
   "version": "1.4.1",
   "description": "The browser package manager",
   "author": "Twitter",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/bower/bower/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": "bower/bower",
   "main": "lib",
   "homepage": "http://bower.io",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/