### PR TITLE
Allow boolean values in bower.json file created by `bower init`

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -58,7 +58,7 @@ function readJson(project, logger) {
 function saveJson(project, logger, json) {
     // Cleanup empty props (null values, empty strings, objects and arrays)
     mout.object.forOwn(json, function (value, key) {
-        if (value == null || mout.lang.isEmpty(value)) {
+        if (!validConfigValue(value)) {
             delete json[key];
         }
     });
@@ -79,6 +79,18 @@ function saveJson(project, logger, json) {
         // Save json (true forces file creation)
         return project.saveJson(true);
     });
+}
+
+// Test if value is of a type supported by bower.json[0] - Object, Array, String, Boolean - or a Number
+// [0]: https://github.com/bower/bower.json-spec
+function validConfigValue(val) {
+    return (
+        mout.lang.isObject(val)  ||
+        mout.lang.isArray(val)   ||
+        mout.lang.isString(val)  ||
+        mout.lang.isBoolean(val) ||
+        mout.lang.isNumber(val)
+    );
 }
 
 function setDefaults(config, json) {

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -49,7 +49,8 @@ describe('bower init', function () {
                 description: 'test-description',
                 moduleType: 'test-moduleType',
                 keywords: [ 'test-keyword' ],
-                license: 'test-license'
+                license: 'test-license',
+                private: true
             });
         });
     });


### PR DESCRIPTION
Hi!

While using `bower init` this morning, I noticed that the resulting bower.json file did not include the "private" key I had chosen a value for. It looks like the behavior of `mout.lang.isEmpty()` was [changed in mout v0.10.0](https://github.com/mout/mout/commit/d80a75510db77fa11e0b6cc795a7d1f432892457) ([discussion](https://github.com/mout/mout/issues/173)), and Bower's dependency on mout introduced this bug, preventing `bower init` from being able to create a complete bower.json.

Interestingly, this buggy(?) behavior [is captured in the bower test for init](https://github.com/bower/bower/blob/master/test/commands/init.js#L34), where the input includes "private", but it is not in the expected output, so forgive me if this behavior is in fact intended :).

Also, I almost never write JavaScript, so please let me know if there are style/other issues to fix.

Thanks for looking!
<3 Ben