### PR TITLE
Components that are not installed by bower should be left alone

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -145,6 +145,7 @@ Manager.prototype.postinstall = function (json) {
 
 Manager.prototype.install = function (json) {
     var componentsDir;
+    var componentsDirContents;
     var that = this;
 
     // If already resolving, error out
@@ -161,15 +162,24 @@ Manager.prototype.install = function (json) {
     return Q.nfcall(mkdirp, componentsDir)
     .then(function () {
         var promises = [];
+        componentsDirContents = fs.readdirSync(componentsDir);
 
         mout.object.forOwn(that._dissected, function (decEndpoint, name) {
             var promise;
             var dst;
             var release = decEndpoint.pkgMeta._release;
+            var exists = mout.array.contains(componentsDirContents, name);
 
             that._logger.action('install', name + (release ? '#' + release : ''), that.toData(decEndpoint));
 
             dst = path.join(componentsDir, name);
+
+            if (exists && !that._installed[name] && !that._config.force) {
+                // There is a folder in the components directory that has
+                // this name, but it was not installed by bower.
+                that._logger.warn('skipped', name + ' was not installed because there is already a non-bower directory with that name in the components directory (' + path.relative(that._config.cwd, dst) + '). You can force installation with --force.');
+                return;
+            }
 
             // Remove existent and copy canonical dir
             promise = Q.nfcall(rimraf, dst)

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -1,5 +1,6 @@
 var expect = require('expect.js');
 var helpers = require('../helpers');
+var fs = require('fs');
 
 describe('bower install', function () {
 
@@ -51,6 +52,27 @@ describe('bower install', function () {
         return helpers.run(install, [[package.path], { save: true }]).then(function() {
             expect(tempDir.read('bower.json')).to.contain('dependencies');
         });
+    });
+
+    it('skips components not installed by bower', function () {
+        package.prepare({
+            '.git': {} //Make a dummy file instead of using slower gitPrepare()
+        });
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package: package.path
+                }
+            }
+        });
+
+        return helpers.run(install).then(function() {
+            var packageFiles = fs.readdirSync(package.path);
+            //presence of .git file implies folder was not overwritten
+            expect(packageFiles).to.contain('.git'); 
+        });
+
     });
 
     it('writes an exact version number to dependencies in bower.json if --save --save-exact flags are used', function () {


### PR DESCRIPTION
This is a rework of PR #1363  with changes as requested.   I was unable to simply build on top of @wibblymat's  commit because I was unable to get the full suite of tests to pass despite much tweaking and debugging.  With the commit being ~200 commits behind master I decided it would be easier to create a new branch off of master and go from there, since most of the code ended up being rewritten for this fix.

Please let me know if there are any additional changes needed!

Thanks,
Anton