### PR TITLE
doc: remove section about completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,21 +81,6 @@ path if needed.
 
 Bower can be configured using JSON in a `.bowerrc` file. Read over available options at [bower.io/docs/config](http://bower.io/docs/config).
 
-## Completion (experimental)
-
-_NOTE_: Completion is still not implemented for the 1.0.0 release
-
-Bower now has an experimental `completion` command that is based on, and works
-similarly to the [npm completion](https://npmjs.org/doc/cli/completion.html). It is
-not available for Windows users.
-
-This command will output a Bash / ZSH script to put into your `~/.bashrc`,
-`~/.bash_profile`, or `~/.zshrc` file.
-
-```sh
-$ bower completion >> ~/.bash_profile
-```
-
 
 ## Support
 


### PR DESCRIPTION
The completion command appears to have been lost during the rewrite
(#1066).  So to avoid confusion it should not be mentioned in the
README.