### PR TITLE
Sped up `bower install` by caching resolved dependencies

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -229,13 +229,14 @@ Manager.prototype.install = function (json) {
     }.bind(this));
 };
 
-Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps) {
+Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps, cache) {
     var names;
     var extra;
 
     var data = {};
 
     upperDeps = upperDeps || [];
+    cache = cache || {};
     data.endpoint = mout.object.pick(decEndpoint, ['name', 'source', 'target']);
 
     if (decEndpoint.canonicalDir) {
@@ -259,12 +260,20 @@ Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps) {
         names = Object.keys(decEndpoint.dependencies).sort();
         names.forEach(function (name) {
 
+            var release = (decEndpoint.dependencies[name].pkgMeta || {})._release;
+            var key = name + (release ? '#' + release : '');
+
             // Prevent from infinite recursion when installing cyclic
             // dependencies
-            if (!mout.array.contains(upperDeps, name)) {
-                data.dependencies[name] = this.toData(decEndpoint.dependencies[name],
-                    extraKeys,
-                    upperDeps.concat(decEndpoint.name));
+            if (!mout.array.contains(upperDeps, key)) {
+                if (cache[key]) {
+                    data.dependencies[name] = cache[key];
+                } else {
+                    data.dependencies[name] = cache[key] = this.toData(decEndpoint.dependencies[name],
+                        extraKeys,
+                        upperDeps.concat(key),
+                        cache);
+                }
             }
         }, this);
     }
@@ -689,7 +698,9 @@ Manager.prototype._electSuitable = function (name, semvers, nonSemvers) {
     // 2 - Transform data
     dataPicks = picks.map(function (pick) {
         var dataPick = this.toData(pick);
-        dataPick.dependants = pick.dependants.map(this.toData, this);
+        dataPick.dependants = pick.dependants.map(function (d) {
+            return this.toData(d);
+        }, this);
         dataPick.dependants.sort(function (dependant1, dependant2) {
             return dependant1.endpoint.name.localeCompare(dependant2.endpoint.name);
         });


### PR DESCRIPTION
The idea is to skip resolving dependencies that have already been scanned. For example, given dependency tree

```
A -> B -> C -> ...
 `-> C -> ...
```

there is no need to look inside C when it's found for the second time. 

In our case time taken by "bower install" dropped from ~2 minutes to under 15 seconds. We also got rid of sporadic "FATAL ERROR: CALL_AND_RETRY_2 Allocation failed - process out of memory".

Things to watch out for: 
- if there is a cache entry, `data.dependencies[name]` gets a reference (not a copy).  

Other notes:
- you could eliminate cache altogether by just skipping same dependencies but tree would look different (outcome would be the same, though) so, not knowing which approach you would prefer, I left everything else as it is.
