### PR TITLE
upgrade to newer semver, fixes #1817,#1845,#1851

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "request-progress": "0.3.1",
     "retry": "0.6.1",
     "rimraf": "^2.2.8",
-    "semver": "^2.3.0",
+    "semver": "^5.0.1",
     "shell-quote": "^1.4.2",
     "stringify-object": "^1.0.0",
     "tar-fs": "^1.4.1",

--- a/test/core/resolvers/gitResolver.js
+++ b/test/core/resolvers/gitResolver.js
@@ -506,7 +506,7 @@ describe('GitResolver', function () {
             .done();
         });
 
-        it('should resolve "*" to the latest version if a repository has valid semver tags, not ignoring pre-releases if they are the only versions', function (next) {
+        it('should fail to resolve "*" if a repository has valid semver tags, ignoring pre-releases if they are the only versions', function (next) {
             var resolver;
 
             GitResolver.refs = function () {
@@ -519,6 +519,31 @@ describe('GitResolver', function () {
 
             resolver = create('foo');
             resolver._findResolution('*')
+                .then(function () {
+                    next(new Error('Should have failed'));
+                }, function (err) {
+                    expect(err).to.be.an(Error);
+                    expect(err.message).to.match(/no tag found that was able to satisfy/i);
+                    expect(err.details).to.match(/0.1.0-rc/i);
+                    expect(err.code).to.equal('ENORESTARGET');
+                    next();
+                })
+                .done();
+        });
+
+        it('should resolve "* || >=0.1.0-rc.0" to the latest version if a repository has valid semver tags, not ignoring pre-releases if they are the only versions', function (next) {
+            var resolver;
+
+            GitResolver.refs = function () {
+                return Q.resolve([
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/master',
+                    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb refs/tags/0.1.0-rc.1',
+                    'cccccccccccccccccccccccccccccccccccccccc refs/tags/0.1.0-rc.2'
+                ]);
+            };
+
+            resolver = create('foo');
+            resolver._findResolution('* || >=0.1.0-rc.0')
             .then(function (resolution) {
                 expect(resolution).to.eql({
                     type: 'version',
@@ -542,7 +567,7 @@ describe('GitResolver', function () {
             };
 
             resolver = create('foo');
-            resolver._findResolution('0.1.*')
+            resolver._findResolution('0.1.* || >=0.1.0-rc.1')
             .then(function (resolution) {
                 expect(resolution).to.eql({
                     type: 'version',
@@ -642,7 +667,7 @@ describe('GitResolver', function () {
             };
 
             resolver = create('foo');
-            resolver._findResolution('~0.2.1')
+            resolver._findResolution('~0.2.1-rc.0')
             .then(function (resolution) {
                 expect(resolution).to.eql({
                     type: 'version',


### PR DESCRIPTION
Upgrading to latest version of semver to fix (#1817, #1845, #1851).

Possible breaking changes in regards to the way semvers handles pre-releases.

If a version has a prerelease tags (for example, 1.2.3-alpha.3) then it will only be allowed to satisfy comparator sets if at least one comparator with the same [major, minor, patch] tuple also has a prerelease tag.

For example, the range >1.2.3-alpha.0 would be allowed to match the version 1.2.3-alpha.7, but it would not be satisfied by * or 1.2.3. See [semvers](https://github.com/npm/node-semver#prerelease-tags) additional details.