### PR TITLE
Add HTTP auth support

### DIFF
--- a/lib/core/resolvers/UrlResolver.js
+++ b/lib/core/resolvers/UrlResolver.js
@@ -109,6 +109,19 @@ UrlResolver.prototype._download = function () {
     var file = path.join(this._tempDir, fileName);
     var reqHeaders = {};
     var that = this;
+    var requestConfig = {
+        proxy: this._remote.protocol === 'https:' ? this._config.httpsProxy : this._config.proxy,
+        strictSSL: this._config.strictSsl,
+        timeout: this._config.timeout,
+        headers: reqHeaders
+    };
+
+    if (this._config.auth && this._config.auth.username && this._config.auth.password) {
+        requestConfig.auth = {
+            username: this._config.auth.username,
+            password: this._config.auth.password
+        };
+    }
 
     if (this._config.userAgent) {
         reqHeaders['User-Agent'] = this._config.userAgent;
@@ -120,12 +133,7 @@ UrlResolver.prototype._download = function () {
     });
 
     // Download the file
-    return download(this._source, file, {
-        proxy: this._remote.protocol === 'https:' ? this._config.httpsProxy : this._config.proxy,
-        strictSSL: this._config.strictSsl,
-        timeout: this._config.timeout,
-        headers: reqHeaders
-    })
+    return download(this._source, file, requestConfig)
     .progress(function (state) {
         var msg;
 


### PR DESCRIPTION
Added HTTP auth support.

Passing auth options to bower will extend the Request with proper credentials:

```
auth = {
  username: 'username',
  password: 'password'
}
```

Also available through CLI args - `--config.auth.username=username --config.auth.password=password `.

This is very useful for defining secured endpoints. We're using it to feed bower with Maven packages, could be potentially used for secure NPM packages.

Also requested by few other people before https://github.com/bower/bower.json-spec/issues/25.