### PR TITLE
No longer prefer installing bower as global

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "test": "grunt test"
   },
   "bin": "bin/bower",
-  "preferGlobal": true,
   "files": [
     "bin",
     "lib",


### PR DESCRIPTION
Installing bower locally if perfectly good. It allows to use different version of bower locally.

The next step is to create bower-cli package that can run local bower installation.