### PR TITLE
Make bower commands work from subdirectories

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,13 +2,21 @@ var tty = require('tty');
 var object = require('mout').object;
 var bowerConfig = require('bower-config');
 var Configstore = require('configstore');
+var findup = require('findup-sync');
+var path = require('path');
 
 var cachedConfigs = {};
 
 function defaultConfig(config) {
     config = config || {};
 
-    var cachedConfig = readCachedConfig(config.cwd || process.cwd());
+    var cwd = path.dirname(findup('bower.json', {
+        cwd: config.cwd || process.cwd()
+    })) || config.cwd || process.cwd();
+
+    config.cwd = cwd;
+
+    var cachedConfig = readCachedConfig(cwd);
 
     return object.merge(cachedConfig, config);
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "configstore": "^0.3.2",
     "decompress-zip": "^0.1.0",
     "deep-sort-object": "~0.1.1",
+    "findup-sync": "^0.2.1",
     "fstream": "^1.0.3",
     "fstream-ignore": "^1.0.2",
     "github": "^0.2.3",

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -133,6 +133,25 @@ describe('bower install', function () {
         });
     });
 
+    it.only('works if bower is run in child directory', function () {
+        package.prepare({ foo: 'bar' });
+
+        tempDir.prepare({
+            '.bowerrc': { directory: 'assets' },
+            'foo/bar/baz.txt': 'Hello world',
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package: package.path
+                }
+            }
+        });
+
+        return helpers.run(install, [undefined, undefined, { cwd: tempDir.path + '/foo/bar' }]).then(function() {
+            expect(tempDir.read('assets/package/foo')).to.be('bar');
+        });
+    });
+
     it('runs preinstall hook', function () {
         package.prepare();
 


### PR DESCRIPTION
IMO it is more pleasant behavior. It tries to find bower.json in parent directories and fallbacks to config.cwd or process.cwd()