### PR TITLE
Use CA certificate option for artifact downloads

### DIFF
--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -74,6 +74,7 @@ GitHubResolver.prototype._checkout = function () {
     return download(tarballUrl, file, {
         proxy: this._config.httpsProxy,
         strictSSL: this._config.strictSsl,
+        ca: this._config.ca.register, // any CA will do?
         timeout: this._config.timeout,
         headers: reqHeaders
     })

--- a/lib/core/resolvers/UrlResolver.js
+++ b/lib/core/resolvers/UrlResolver.js
@@ -57,6 +57,7 @@ UrlResolver.prototype._hasNew = function (canonicalDir, pkgMeta) {
     return Q.nfcall(request.head, this._source, {
         proxy: this._remote.protocol === 'https:' ? this._config.httpsProxy : this._config.proxy,
         strictSSL: this._config.strictSsl,
+        ca: this._config.ca.register, // any CA will do?
         timeout: this._config.timeout,
         headers: reqHeaders
     })
@@ -123,6 +124,7 @@ UrlResolver.prototype._download = function () {
     return download(this._source, file, {
         proxy: this._remote.protocol === 'https:' ? this._config.httpsProxy : this._config.proxy,
         strictSSL: this._config.strictSsl,
+        ca: this._config.ca.register, // any CA will do?
         timeout: this._config.timeout,
         headers: reqHeaders
     })


### PR DESCRIPTION
Following #419. Without this, repository fetching works, but fetching tar balls does not.

Note that this works better together with bower/config#28.

As I am not sure why there are CA options for `search[]`, `register` and `publish`, I just picked one to use for tar balls. Another option would be to add a new property for "generic use", but that would require more bower/config changes.

In our setup, we were able to run a `bower install` behind a corporate proxy with `strict-ssl` enabled, by adding the proxy's root CA to `.bowerrc`. For that, modifying `GitHubResolver` was enough, but it seems likely that `UrlResolver` needs the same changes, so included them too.