### PR TITLE
Add shorthand for version of options in help.json

### DIFF
--- a/templates/json/help.json
+++ b/templates/json/help.json
@@ -62,6 +62,7 @@
             "description": "Allows running commands as root"
         },
         {
+            "shorthand":   "-v",
             "flag":        "--version",
             "description": "Output Bower version"
         },


### PR DESCRIPTION
"-v" shorthand aleady supported of cli opeion for output version

```
# same output
$ bower --version
$ bower -v
```

```
Usage:

    bower <command> [<args>] [<options>]
Commands:

    cache                   Manage bower cache
    help                    Display help information about Bower
    home                    Opens a package homepage into your favorite browser
    info                    Info of a particular package
    init                    Interactively create a bower.json file
    install                 Install a package locally
    link                    Symlink a package folder
    list                    List local packages - and possible updates
    login                   Authenticate with GitHub and store credentials
    lookup                  Look up a package URL by name
    prune                   Removes local extraneous packages
    register                Register a package
    search                  Search for a package by name
    update                  Update a local package
    uninstall               Remove a local package
    unregister              Remove a package from the registry
    version                 Bump a package version
Options:

    -f, --force             Makes various commands more forceful
    -j, --json              Output consumable JSON
    -l, --log-level         What level of logs to report
    -o, --offline           Do not hit the network
    -q, --quiet             Only output important information
    -s, --silent            Do not output anything, besides errors
    -V, --verbose           Makes output more verbose
    --allow-root            Allows running commands as root
    -v, --version           Output Bower version
    --no-color              Disable colors
See 'bower help <command>' for more information on a specific command.
```