### PR TITLE
Include package name in error info when a version is not found.

### DIFF
--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -144,7 +144,7 @@ GitResolver.prototype._findResolution = function (target) {
                 throw createError('No tag found that was able to satisfy ' + target, 'ENORESTARGET', {
                     details: !versions.length ?
                         'No versions found in ' + that._source :
-                        'Available versions: ' + versions.map(function (version) { return version.version; }).join(', ')
+                        'Available versions in ' + that._source + ': ' + versions.map(function (version) { return version.version; }).join(', ')
                 });
             });
         });

--- a/lib/core/resolvers/SvnResolver.js
+++ b/lib/core/resolvers/SvnResolver.js
@@ -188,7 +188,7 @@ SvnResolver.prototype._findResolution = function (target) {
                 throw createError('No tag found that was able to satisfy ' + target, 'ENORESTARGET', {
                     details: !versions.length ?
                         'No versions found in ' + that._source :
-                        'Available versions: ' + versions.map(function (version) { return version.version; }).join(', ')
+                        'Available versions in ' + that._source + ': ' + versions.map(function (version) { return version.version; }).join(', ')
                 });
             });
         });

--- a/test/core/resolvers/gitResolver.js
+++ b/test/core/resolvers/gitResolver.js
@@ -706,7 +706,7 @@ describe('GitResolver', function () {
             }, function (err) {
                 expect(err).to.be.an(Error);
                 expect(err.message).to.match(/was able to satisfy ~0.2.0/i);
-                expect(err.details).to.match(/available versions: 0\.1\.1, 0\.1\.0/i);
+                expect(err.details).to.match(/available versions in foo: 0\.1\.1, 0\.1\.0/i);
                 expect(err.code).to.equal('ENORESTARGET');
                 next();
             })

--- a/test/core/resolvers/svnResolver.js
+++ b/test/core/resolvers/svnResolver.js
@@ -503,7 +503,7 @@ else describe('SvnResolver', function () {
             }, function (err) {
                 expect(err).to.be.an(Error);
                 expect(err.message).to.match(/was able to satisfy ~0.2.0/i);
-                expect(err.details).to.match(/available versions: 0\.1\.1, 0\.1\.0/i);
+                expect(err.details).to.match(/available versions in foo: 0\.1\.1, 0\.1\.0/i);
                 expect(err.code).to.equal('ENORESTARGET');
                 next();
             })


### PR DESCRIPTION
Prior to this commit, when specifying a package version that cannot
be resolved, but other versions are available, the error message
did not state which what package failed, allowing for confusion.

For example, you might see:

```
bower ENORESTARGET  No tag found that was able to satisfy 1.0.2

Additional error details:
Available versions: 1.0.1, 1.0.0
```

After this change, in the above situation the svn and git resolvers
will produce the following:

```
bower ENORESTARGET  No tag found that was able to satisfy 1.0.2

Additional error details:
Available versions in somelib: 1.0.1, 1.0.0
```