### PR TITLE
Adds timer to usage statistics prompt

### DIFF
--- a/lib/util/analytics.js
+++ b/lib/util/analytics.js
@@ -45,7 +45,14 @@ analytics.setup = function setup (config) {
             if (insight.optOut !== undefined) {
                 deferred.resolve(!insight.optOut);
             } else {
+                // Add timeout before giving up on getting an answer, default to 10 sec
+                var timeout = parseInt(config.permissionTimer || 10, 10) * 1000;
+                var permissionTimeout = setTimeout(function () {
+                    deferred.resolve(false);
+                }, timeout);
                 insight.askPermission(null, function(err, optIn) {
+                    // Upon getting an answer, clear the permission timeout
+                    clearTimeout(permissionTimeout);
                     // optIn callback param was exactly opposite before 0.4.3
                     // so we force at least insight@0.4.3 in package.json
                     deferred.resolve(optIn);


### PR DESCRIPTION
This PR adds a 10 second timer to the usage statistics permission prompt shown on first run of Bower.

The code has not been given a serious workthrough or been given tests, because this is primarily to demonstrate an idea of how to possibly resolve in issue that's been making people crazy for the last one and a half year (https://github.com/bower/bower/issues/1102).