### PR TITLE
allow --config.resolvers={required package}

### DIFF
--- a/lib/core/resolverFactory.js
+++ b/lib/core/resolverFactory.js
@@ -44,8 +44,15 @@ function getConstructor(decEndpoint, options, registryClient) {
     // its "match" to check if given resolves supports given decEndpoint
     addResolver(function () {
         var selectedResolver;
+        var resolverNames;
 
-        var resolverNames = config.resolvers || [];
+        if (Array.isArray(config.resolvers)) {
+            resolverNames = config.resolvers;
+        } else if (!!config.resolvers) {
+            resolverNames = config.resolvers.split(',');
+        } else {
+            resolverNames = [];
+        }
 
         var resolverPromises = resolverNames.map(function (resolverName) {
             var resolver = resolvers[resolverName]


### PR DESCRIPTION
This PR public pluggable resolvers configuration in **.bowerrc** to bower cli.   This will allow you to pass resolvers interactively especially in build task. e.g.:

```bash
bower install [optional pkg names] --config.resolvers="My-resolver1"
//or
bower install [optional pkg names] --config.resolvers="/Users/xxx/anypath/packagename"
//or
bower install [optional pkg names] --config.resolvers="/Users/xxx/anypath-without-comma/packagename, other-resolver-package-in-bowers-range"

```