### PR TITLE
Bumps Insight to reduce prompt friction

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "graceful-fs": "^3.0.5",
     "handlebars": "^2.0.0",
     "inquirer": "0.8.0",
-    "insight": "^0.5.0",
+    "insight": "^0.7.0",
     "is-root": "^1.0.0",
     "junk": "^1.0.0",
     "lockfile": "^1.0.0",


### PR DESCRIPTION
The purpose of this PR is to reduce issues with the usage statistics prompt. This is done by bumping to the latest version of Insight, which include a check for `process.env.CI` before showing the prompt and also adds a 30 second timeout to the prompt.

This should negate most (if not all) issues raised by #1102.