### PR TITLE
Adding an httpsInsteadOfGit config option

### DIFF
--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -32,8 +32,8 @@ function GitHubResolver(decEndpoint, config, logger) {
     // Check if it's public
     this._public = mout.string.startsWith(this._source, 'git://');
 
-    // Use https:// rather than git:// if on a proxy
-    if (this._config.proxy || this._config.httpsProxy) {
+    // Use https:// rather than git:// if on a proxy or the httpsInsteadOfGit:true option is passed
+    if (this._config.proxy || this._config.httpsProxy || this._config.httpsInsteadOfGit) {
         this._source = this._source.replace('git://', 'https://');
     }
 

--- a/test/core/resolverFactory.js
+++ b/test/core/resolverFactory.js
@@ -663,6 +663,25 @@ describe('resolverFactory', function () {
         .done();
     });
 
+    it('should use https:// instead of git:// if the httpsInsteadOfGit config is set to true', function (next) {
+        callFactory({ source: 'bower/bower' })
+        .then(function (resolver) {
+            var config = {
+                httpsInsteadOfGit: true
+            };
+
+            expect(resolver.getSource()).to.equal('git://github.com/bower/bower.git');
+
+            return callFactory({ source: 'IndigoUnited/promptly' }, config);
+        })
+        .then(function (resolver) {
+            expect(resolver.getSource()).to.equal('https://github.com/IndigoUnited/promptly.git');
+            next();
+        })
+        .done();
+    });
+
+
     it.skip('should use config.cwd when resolving relative paths');
 
     it('should not swallow constructor errors when instantiating resolvers', function (next) {


### PR DESCRIPTION
This new config option provides yet another way to force git requests to use https instead of git.

While `git config --global url."https://".insteadOf git://` works well in local development, it is possible that a CI build server may not allow for that configuration, and setting the `bower_https_proxy` environment variable globally may not be desired to allow for individual project configuration. This new `"httpsInsteadOfGit":true` option allows for that to be set on a per-project basis.

Note that this is currently possible by defining `"https-proxy":"https://github.com"` in .bowerrc, so for this pull request I'm just seeking to make that functionality more explicit for those seeking to do that, since it [seems to be a common need](http://stackoverflow.com/questions/15669091/bower-install-using-only-https).