### PR TITLE
Stop throwing Error on readdir, readdirSync symlink to folder

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -11,6 +11,12 @@ module.exports.readdir = function (dir, callback) {
 
         if (stats.isDirectory()) {
             return readdir(dir, callback);
+        } else if (stats.isSymbolicLink()) {
+            fs.readlink(dir, function(err, linkedDir) {
+              if (err) return callback(err);
+
+              return module.exports.readdir(linkedDir, callback);
+            });
         } else {
             var error = new Error('ENOTDIR, not a directory \'' + dir + '\'');
             error.code = 'ENOTDIR';
@@ -26,6 +32,9 @@ module.exports.readdirSync = function (dir) {
 
     if (stats.isDirectory()) {
         return readdirSync(dir);
+    } else if (stats.isSymbolicLink()) {
+        var linkedDir = fs.readlinkSync(dir);
+        return module.exports.readdirSync(linkedDir);
     } else {
         var error = new Error();
         error.code = 'ENOTDIR';


### PR DESCRIPTION
If target is symlinked to directory, Error should not be raised.