### PR TITLE
strip trailing slash in urlResolver

### DIFF
--- a/lib/core/resolvers/UrlResolver.js
+++ b/lib/core/resolvers/UrlResolver.js
@@ -104,8 +104,18 @@ UrlResolver.prototype._resolve = function () {
 
 // -----------------
 
+UrlResolver.prototype._parseSourceURL = function (_url) {
+    return url.parse(path.basename(_url)).pathname;
+};
+
 UrlResolver.prototype._download = function () {
-    var fileName = url.parse(path.basename(this._source)).pathname;
+    var fileName = this._parseSourceURL(this._source);
+
+    if (!fileName) {
+      this._source = this._source.replace(/\/(?=\?|#)/, '');
+      fileName = this._parseSourceURL(this._source);
+    }
+
     var file = path.join(this._tempDir, fileName);
     var reqHeaders = {};
     var that = this;


### PR DESCRIPTION
[I discovered](https://github.com/Modernizr/modernizr-neue/issues/55) that urls with a trailing slash fail for Modernizr's use case. Because of where we add the zip (e.g. after the query string) the `fileName` prop is null. As a result it throws an error without this fix.