### PR TITLE
Fix/Support shallow clone for ssh protocol

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -19,14 +19,14 @@ function GitRemoteResolver(decEndpoint, config, logger) {
         this._name = this._name.slice(0, -4);
     }
 
-    // Get the host of this source
+    // Get the remote of this source
     if (!/:\/\//.test(this._source)) {
-        this._host = url.parse('ssh://' + this._source).host;
+        this._remote = url.parse('ssh://' + this._source);
     } else {
-        this._host = url.parse(this._source).host;
+        this._remote = url.parse(this._source);
     }
-
-    this._remote = url.parse(this._source);
+    
+    this._host = this._remote.host;
 
     // Verify whether the server supports shallow cloning
     this._shallowClone = this._supportsShallowCloning;

--- a/test/core/resolvers/gitRemoteResolver.js
+++ b/test/core/resolvers/gitRemoteResolver.js
@@ -356,6 +356,26 @@ describe('GitRemoteResolver', function () {
             });
         });
 
+        it('should evaluate to true when source is a ssh protocol and host is defined to support shallow cloning', function (next) {
+            var testSource = 'git@foo:bar.git';
+
+            var MyGitRemoteResolver = gitRemoteResolverFactory(
+                createCmdHandlerFn(testSource, multiline(function () {/*
+                    foo: bar
+                    Content-Type: application/x-git-upload-pack-advertisement
+                    1234: 5678
+                */}))
+            );
+
+            var resolver = new MyGitRemoteResolver({ source: testSource }, defaultConfig({ shallowCloneHosts: ['foo'] }), logger);
+
+            resolver._shallowClone().then(function (shallowCloningSupported) {
+                expect(shallowCloningSupported).to.be(true);
+
+                next();
+            });
+        });
+
         it('should cache hosts that support shallow cloning', function (next) {
             var testSource = 'https://foo/bar.git';
 


### PR DESCRIPTION
I found that GitRemoteResolver is not supports shallow cloning if the source is a ssh protocol.

This is caused by

```
// Constructor
this._remote = url.parse(this._source);
```

If the source is `git@bitbucket.org:foo/bar.git`, it cannot find the protocol
that lead to make the condition inside _supportsShallowCloning() is always false

```
// _supportsShallowCloning
if (this._remote == null || this._remote.protocol == null) {
  return Q.resolve(false);
}
```
