### PR TITLE
use --non-interactive when running svn client

### DIFF
--- a/lib/core/resolvers/SvnResolver.js
+++ b/lib/core/resolvers/SvnResolver.js
@@ -86,13 +86,13 @@ SvnResolver.prototype._export = function () {
     });
 
     if (resolution.type === 'commit') {
-        promise = cmd('svn', ['export', '--force', this._source + '/trunk', '-r' + resolution.commit, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', '--non-interactive', this._source + '/trunk', '-r' + resolution.commit, this._tempDir]);
     } else if (resolution.type === 'branch' && resolution.branch === 'trunk') {
-        promise = cmd('svn', ['export', '--force', this._source + '/trunk', this._tempDir]);
+        promise = cmd('svn', ['export', '--force', '--non-interactive', this._source + '/trunk', this._tempDir]);
     } else if (resolution.type === 'branch') {
-        promise = cmd('svn', ['export', '--force', this._source + '/branches/' + resolution.branch, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', '--non-interactive', this._source + '/branches/' + resolution.branch, this._tempDir]);
     } else {
-        promise = cmd('svn', ['export', '--force', this._source + '/tags/' + resolution.tag, this._tempDir]);
+        promise = cmd('svn', ['export', '--force', '--non-interactive', this._source + '/tags/' + resolution.tag, this._tempDir]);
     }
 
     // Throttle the progress reporter to 1 time each sec
@@ -324,7 +324,7 @@ SvnResolver.tags = function (source) {
         return Q.resolve(value);
     }
 
-    value = cmd('svn', ['list', source + '/tags', '--verbose'])
+    value = cmd('svn', ['list', source + '/tags', '--verbose', '--non-interactive'])
     .spread(function (stout) {
         var tags = SvnResolver.parseSubversionListOutput(stout.toString());
 
@@ -349,7 +349,7 @@ SvnResolver.branches = function (source) {
         return Q.resolve(value);
     }
 
-    value = cmd('svn', ['list', source + '/branches', '--verbose'])
+    value = cmd('svn', ['list', source + '/branches', '--verbose', '--non-interactive'])
     .spread(function (stout) {
         var branches = SvnResolver.parseSubversionListOutput(stout.toString());
 


### PR DESCRIPTION
Prevents svn CLI client to hang forever with no feedback to the user, upon any server connection errors that request user input. Fixes #1968