### PR TITLE
fix passing options to request

### DIFF
--- a/lib/util/download.js
+++ b/lib/util/download.js
@@ -76,7 +76,7 @@ function fetch(url, file, options) {
         var status = res.statusCode;
 
         if (status < 200 || status >= 300) {
-            return deferred.reject(createError('Status code of ' + status, 'EHTTP'));
+            return writeStream.emit('error', (createError('Status code of ' + status, 'EHTTP')));
         }
 
         response = res;
@@ -89,8 +89,7 @@ function fetch(url, file, options) {
         deferred.notify(state);
     })
     .on('error', function (error) {
-        writeStream.destroy();
-        deferred.reject(error);
+        writeStream.emit('error', error);
     })
     .on('end', function () {
         // Check if the whole file was downloaded

--- a/lib/util/download.js
+++ b/lib/util/download.js
@@ -5,7 +5,6 @@ var mout = require('mout');
 var retry = require('retry');
 var createError = require('./createError');
 var createWriteStream = require('fs-write-stream-atomic');
-var userAgent = require('./userAgent');
 
 var errorCodes = [
     'EADDRINFO',
@@ -24,19 +23,16 @@ function download(url, file, options) {
         factor: 2,
         minTimeout: 1000,
         maxTimeout: 35000,
-        randomize: true
+        randomize: true,
+        progressDelay: progressDelay
     }, options || {});
 
     // Retry on network errors
     operation = retry.operation(options);
 
     operation.attempt(function () {
-        Q.fcall(fetch, url, file, {
-            progressDelay: progressDelay,
-            headers: {
-              'User-Agent': userAgent
-            }
-        }).then(function(response) {
+        Q.fcall(fetch, url, file, options)
+        .then(function(response) {
             deferred.resolve(response);
         }).fail(function (error) {
             // Save timeout before retrying to report
@@ -93,6 +89,7 @@ function fetch(url, file, options) {
         deferred.notify(state);
     })
     .on('error', function (error) {
+        writeStream.destroy();
         deferred.reject(error);
     })
     .on('end', function () {

--- a/test/util/download.js
+++ b/test/util/download.js
@@ -1,0 +1,95 @@
+var expect = require('expect.js');
+var helpers = require('../helpers');
+var nock = require('nock');
+var path = require('path');
+var Q = require('q');
+
+var fs = require('../../lib/util/fs');
+var download = require('../../lib/util/download');
+
+describe('download', function () {
+
+    var tempDir = new helpers.TempDir(),
+        source = path.resolve(__dirname, '../assets/package-tar.tar.gz'),
+        destination = tempDir.getPath('package.tar.gz');
+
+    function downloadTest(opts) {
+        var deferred = Q.defer();
+
+        tempDir.prepare();
+
+        opts.response(
+            nock('https://bower.io', opts.nockOpts)
+                .get('/package.tar.gz'));
+
+        download('https://bower.io/package.tar.gz', destination, opts.downloadOpts)
+            .then(function () {
+                opts.expect();
+                deferred.resolve();
+            }, function () {
+                opts.expectError();
+                deferred.resolve();
+            })
+            .done();
+
+        return deferred.promise;
+    }
+
+    it('download file to directory', function () {
+        return downloadTest({
+            response: function (nock) {
+                nock.replyWithFile(200, source);
+            },
+            expect: function () {
+                expect(fs.existsSync(destination)).to.be(true);
+                expect(fs.readdirSync(tempDir.path)).to.have.length(1);
+            }
+        });
+    });
+
+    it('pass custom user-agent to server', function () {
+        var userAgent = 'Custom User-Agent';
+        return downloadTest({
+            nockOpts: {
+                reqheaders: {
+                    'user-agent': userAgent
+                }
+            },
+            downloadOpts: {
+                headers: {
+                    'User-Agent': userAgent
+                }
+            },
+            response: function (nock) {
+                nock.replyWithFile(200, source);
+            },
+            expect: function () {
+                expect(fs.existsSync(destination)).to.be(true);
+                expect(fs.readdirSync(tempDir.path)).to.have.length(1);
+            }
+        });
+    });
+
+    it('handle server response 404', function () {
+        return downloadTest({
+            response: function (nock) {
+                nock.reply(404);
+            },
+            expectError: function () {
+                expect(fs.readdirSync(tempDir.path)).to.be.empty();
+            }
+        });
+    });
+
+    it('handle network error', function () {
+        return downloadTest({
+            response: function (nock) {
+                nock.replyWithError('network error');
+            },
+            expectError: function () {
+                expect(fs.readdirSync(tempDir.path)).to.be.empty();
+            }
+        });
+    });
+
+});

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -1,4 +1,5 @@
 describe('util', function () {
     require('./removeIgnores');
     require('./analytics');
+    require('./download');
 });


### PR DESCRIPTION
options from download need to be pass to request library that make HTTP
request

Also when there is http error stream need to be closed otherwise there
is issue reported that unlink operation is not permitted on Windows