### PR TITLE
remove hint to use --allow-root flag from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ $ bower uninstall <package-name>
 
 On `prezto` or `oh-my-zsh`, do not forget to `alias bower='noglob bower'` or `bower install jquery\#1.9.1`
 
-### Running commands with sudo
+### Never run Bower with sudo
 
 Bower is a user command, there is no need to execute it with superuser permissions.
-However, if you still want to run commands with sudo, use `--allow-root` option.
 
 ### Windows users
 


### PR DESCRIPTION
The readme said there is no need to run Bower with root permissions and I totally agree to that. Since [quite a few people use this in production](https://github.com/search?utf8=%E2%9C%93&q=file%3ADockerfile+%22--allow-root%22&type=Code&ref=searchresults), it might be a good idea to remove the flag from the most prominent part of the documentation. 