### PR TITLE
Allow install of non semver tags by custom resolvers

### DIFF
--- a/lib/core/resolvers/pluginResolverFactory.js
+++ b/lib/core/resolvers/pluginResolverFactory.js
@@ -121,11 +121,26 @@ function pluginResolverFactory(resolverFactory, bower) {
                             that._version = maxRelease.version;
                             that._release = that._decEndpoint.target = maxRelease.target;
                         } else {
-                            throw createError('No version found that was able to satisfy ' + target, 'ENORESTARGET', {
-                                details: !versions.length ?
+                            var res;
+                            if (resolver.allowNonSemver != undefined && resolver.allowNonSemver) {
+                                if (target != "*") {
+                                    for(var release in result) {
+                                        if (result[release].target == target) {
+                                            res = target;
+                                        }
+                                    }
+                                }
+                            }
+                            if (res != undefined) {
+                                that._version = res;
+                                that._release = that._decEndpoint.target = res;
+                            } else {
+                                throw createError('No version found that was able to satisfy ' + target, 'ENORESTARGET', {
+                                    details: !versions.length ?
                                     'No versions found in ' + that.getSource() :
                                     'Available versions: ' + versions.map(function (version) { return version.version; }).join(', ')
-                            });
+                                });
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Currently the bower code blocks the resolution of bower packages with non semantic versions tags (for example, 19.0). We do understand that bower packages should use semantic versions, however, there are still a few packages out there that don't. This pull request adds the option for custom resolvers to hint whether they they allow non semantic versions.
