### PR TITLE
(temp - travis trigger) fix passing options to request

### DIFF
--- a/lib/util/download.js
+++ b/lib/util/download.js
@@ -5,7 +5,6 @@ var mout = require('mout');
 var retry = require('retry');
 var createError = require('./createError');
 var createWriteStream = require('fs-write-stream-atomic');
-var userAgent = require('./userAgent');
 
 var errorCodes = [
     'EADDRINFO',
@@ -24,19 +23,16 @@ function download(url, file, options) {
         factor: 2,
         minTimeout: 1000,
         maxTimeout: 35000,
-        randomize: true
+        randomize: true,
+        progressDelay: progressDelay
     }, options || {});
 
     // Retry on network errors
     operation = retry.operation(options);
 
     operation.attempt(function () {
-        Q.fcall(fetch, url, file, {
-            progressDelay: progressDelay,
-            headers: {
-              'User-Agent': userAgent
-            }
-        }).then(function(response) {
+        Q.fcall(fetch, url, file, options)
+        .then(function(response) {
             deferred.resolve(response);
         }).fail(function (error) {
             // Save timeout before retrying to report
@@ -93,6 +89,7 @@ function fetch(url, file, options) {
         deferred.notify(state);
     })
     .on('error', function (error) {
+        writeStream.destroy();
         deferred.reject(error);
     })
     .on('end', function () {


### PR DESCRIPTION
options from download need to be pass to request library that make HTTP
request

Also when there is http error stream need to be closed otherwise there
is issue reported that unlink operation is not permitted on Windows