### PR TITLE
Show error if .bowerrc is a directory

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,8 @@ var tty = require('tty');
 var object = require('mout').object;
 var bowerConfig = require('bower-config');
 var Configstore = require('configstore');
+var fs = require('./util/fs');
+var createError = require('./util/createError');
 
 var current;
 
@@ -12,6 +14,16 @@ function defaultConfig(config) {
 }
 
 function readCachedConfig(cwd, overwrites) {
+    var bowerrcPath = cwd + '/.bowerrc';
+    var cli = require('./util/cli');
+
+    // Check if .bowerrc is a directory
+    if (fs.existsSync(bowerrcPath) && fs.statSync(bowerrcPath).isDirectory()) {
+        var renderer = cli.getRenderer('', false, {color: true});
+        renderer.error(createError('.bowerrc should not be a directory', 'EBOWERRCISDIR'));
+        process.exit(1);
+    }
+
     current = bowerConfig.create(cwd).load(overwrites);
 
     var config = current.toObject();
@@ -35,8 +47,6 @@ function readCachedConfig(cwd, overwrites) {
 
     // Merge common CLI options into the config
     if (process.bin === 'bower') {
-        var cli = require('./util/cli');
-
         object.mixIn(config, cli.readOptions({
             force: { type: Boolean, shorthand: 'f' },
             offline: { type: Boolean, shorthand: 'o' },


### PR DESCRIPTION
Fixes #2022

### Problem

Bower crashes if `.bowerrc` is a directory.

### Solution

Show a Bower error if `.bowerrc` is a directory.