### PR TITLE
Supports ~/ paths to cwd field in .bowerrc

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@ var tty = require('tty');
 var object = require('mout').object;
 var bowerConfig = require('bower-config');
 var Configstore = require('configstore');
+var untildify = require('untildify');
 
 var current;
 
@@ -47,6 +48,9 @@ function readCachedConfig(cwd, overwrites) {
             silent: { type: Boolean, shorthand: 's' }
         }));
     }
+
+    // Convert tilde path to home path
+    config.cwd = untildify(config.cwd);
 
     return config;
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1067,6 +1067,16 @@
       "version": "0.0.24",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
     },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "dependencies": {
+        "os-homedir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+        }
+      }
+    },
     "update-notifier": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "stringify-object": "^1.0.0",
     "tar-fs": "^1.4.1",
     "tmp": "0.0.24",
+    "untildify": "^2.1.0",
     "update-notifier": "^0.3.0",
     "user-home": "^1.1.0",
     "which": "^1.0.8"

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -2,6 +2,8 @@ var expect = require('expect.js');
 var helpers = require('../helpers');
 var nock = require('nock');
 var fs = require('../../lib/util/fs');
+var untildify = require('untildify');
+var path = require('path');
 
 describe('bower install', function () {
 
@@ -382,6 +384,33 @@ describe('bower install', function () {
     ]).fail(function(error) {
       expect(error.message).to.equal('Status code of 500');
       nock.enableNetConnect();
+    });
+  });
+
+  it('Use tilde as home directly in cwd', function () {
+    package.prepare();
+
+    // Build a same path with the tempDir including a tilde
+    var cwd = '~';
+    for (var i = 1; untildify('~').split(path.sep).length > i; i++) {
+      cwd += path.sep + '..';
+    }
+    cwd += tempDir.getPath('.');
+
+    tempDir.prepare({
+      'bower.json': {
+        name: 'test',
+        dependencies: {
+          package: package.path
+        }
+      },
+      '.bowerrc': {
+        cwd: cwd
+      }
+    });
+
+    return helpers.run(install).then(function() {
+      expect(tempDir.exists('bower_components/package')).to.be(true);
     });
   });
 });


### PR DESCRIPTION
Updates:
+ Add untildify module
+ Update config.js to convert tilde path to home path

Fixes #1784