### PR TITLE
Fix #2047 LRU cache key is undefined

### DIFF
--- a/lib/core/resolvers/GitRemoteResolver.js
+++ b/lib/core/resolvers/GitRemoteResolver.js
@@ -112,14 +112,22 @@ GitRemoteResolver.prototype._slowClone = function (resolution) {
 GitRemoteResolver.prototype._fastClone = function (resolution) {
     var branch,
         args,
+        host,
         that = this;
 
     branch = resolution.tag || resolution.branch;
     args = ['clone',  this._source, '-b', branch, '--progress', '.'];
 
     return this._shallowClone().then(function (shallowCloningSupported) {
+        // Get the host of this source
+        if (!/:\/\//.test(this._source)) {
+            host = url.parse('ssh://' + this._source).host;
+        } else {
+            host = url.parse(this._source).host;
+        }
+
         // If the host does not support shallow clones, we don't use --depth=1
-        if (shallowCloningSupported && !GitRemoteResolver._noShallow.get(this._host)) {
+        if (shallowCloningSupported && !GitRemoteResolver._noShallow.get(host)) {
             args.push('--depth', 1);
         }
 


### PR DESCRIPTION
this._host is undefined in GitRemoteResolver.prototype._fastClone

### Before:
```shell
bower git:(bugfix/2047) mocha test/core/resolvers/gitRemoteResolver.js

  GitRemoteResolver
    .constructor
      ✓ should guess the name from the path (52ms)
    .resolve
      ✓ should checkout correctly if resolution is a branch (172ms)
      ✓ should checkout correctly if resolution is a tag (103ms)
      ✓ should checkout correctly if resolution is a commit (104ms)
      - should handle gracefully servers that do not support --depth=1
      - should report progress when it takes too long to clone
      shallow cloning
TypeError: LRU: key must be a string or number. Almost certainly a bug! undefined
    at typeCheckKey (/Users/yankun/bower/node_modules/lru-cache/lib/lru-cache.js:20:19)
    at LRUCache.get (/Users/yankun/bower/node_modules/lru-cache/lib/lru-cache.js:230:3)
    at /Users/yankun/bower/lib/core/resolvers/GitRemoteResolver.js:129:70
    at _fulfilled (/Users/yankun/bower/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/Users/yankun/bower/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/Users/yankun/bower/node_modules/q/q.js:796:13)
    at /Users/yankun/bower/node_modules/q/q.js:857:14
    at runSingle (/Users/yankun/bower/node_modules/q/q.js:137:13)
    at flush (/Users/yankun/bower/node_modules/q/q.js:125:13)
    at doNTCallback0 (node.js:430:9)
    at process._tickCallback (node.js:359:13)
        ✓ should add --depth=1 when shallow cloning is supported
        ✓ should not add --depth=1 when shallow cloning is not supported
    #refs
      ✓ should resolve to the references of the remote repository
      ✓ should cache the results
    #_supportsShallowCloning
      ✓ should call ls-remote when using http protocol
      ✓ should call ls-remote when using https protocol
      ✓ should evaluate to false when the URL can not be parsed
      ✓ should evaluate to true when the smart content type is returned
      ✓ should cache hosts that support shallow cloning
      ✓ should cache hosts that support shallow cloning across multiple repos
      ✓ should run separate checks for separate hosts
```

### After:
```shell
bower git:(bugfix/2047) mocha test/core/resolvers/gitRemoteResolver.js

  GitRemoteResolver
    .constructor
      ✓ should guess the name from the path (52ms)
    .resolve
      ✓ should checkout correctly if resolution is a branch (172ms)
      ✓ should checkout correctly if resolution is a tag (103ms)
      ✓ should checkout correctly if resolution is a commit (104ms)
      - should handle gracefully servers that do not support --depth=1
      - should report progress when it takes too long to clone
      shallow cloning
        ✓ should add --depth=1 when shallow cloning is supported
        ✓ should not add --depth=1 when shallow cloning is not supported
    #refs
      ✓ should resolve to the references of the remote repository
      ✓ should cache the results
    #_supportsShallowCloning
      ✓ should call ls-remote when using http protocol
      ✓ should call ls-remote when using https protocol
      ✓ should evaluate to false when the URL can not be parsed
      ✓ should evaluate to true when the smart content type is returned
      ✓ should cache hosts that support shallow cloning
      ✓ should cache hosts that support shallow cloning across multiple repos
      ✓ should run separate checks for separate hosts
```