### PR TITLE
Add directory test for install command

### DIFF
--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -384,4 +384,17 @@ describe('bower install', function () {
       done();
     });
   });
+
+  
+  it('errors if the components directory is not a directory', function () {
+    tempDir.prepare({
+      '.bowerrc': {
+        directory: '.bowerrc'
+      }     
+    });
+    
+    return helpers.run(install).fail(function(error) {
+      expect(error.code).to.equal('ENOTDIR');
+    });
+  });
 });


### PR DESCRIPTION
This test tries to run `bower install` when the `.bowerrc` specifies a directory that's actually a file. Super trivial, but it should increase coverage for /lib/util/fs.js to 100%. Also, my first pull request for Bower. Please let me know if anything needs changing.