### PR TITLE
Only update the packages requested by the user

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -76,6 +76,8 @@ Manager.prototype.configure = function (setup) {
     // Uniquify targets
     this._targets = this._uniquify(this._targets);
 
+    this._requested = setup.requested || [];
+
     // Force-latest
     this._forceLatest = !!setup.forceLatest;
 
@@ -94,6 +96,8 @@ Manager.prototype.configure = function (setup) {
  *
  */
 Manager.prototype.resolve = function () {
+    var name;
+
     // If already resolving, error out
     if (this._working) {
         return Q.reject(createError('Already working', 'EWORKING'));
@@ -112,7 +116,12 @@ Manager.prototype.resolve = function () {
     // Otherwise, fetch each target from the repository
     // and let the process roll out
     } else {
-        this._targets.forEach(this._fetch.bind(this));
+        this._targets.forEach(function (target) {
+            name = target.name || target.source;
+            if (!this._requested.length || mout.array.contains(this._requested, name)) {
+                this._fetch(target);
+            }
+        }.bind(this));
     }
 
     // Unset working flag when done

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -38,6 +38,9 @@ Project.prototype.install = function (decEndpoints, options, config) {
     this._options = options || {};
     this._config = config || {};
     this._working = true;
+    this._endpoints = decEndpoints.map(function (endpoint) {
+        return endpoint.name || endpoint.source;
+    });
 
     // Analyse the project
     return this._analyse()
@@ -131,6 +134,7 @@ Project.prototype.update = function (names, options) {
 
     this._options = options || {};
     this._working = true;
+    this._endpoints = names;
 
     // Analyse the project
     return this._analyse()
@@ -558,6 +562,7 @@ Project.prototype._bootstrap = function (targets, resolved, incompatibles) {
         targets: targets,
         resolved: resolved,
         incompatibles: incompatibles,
+        requested: this._endpoints,
         resolutions: this._json.resolutions,
         installed: installed,
         forceLatest: this._options.forceLatest

--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -206,8 +206,9 @@ Project.prototype.update = function (names, options) {
                     }
 
                     var jsonEndpoint = endpointParser.decomposed2json(target);
+                    var src = target.name !== target.source ? target.source + '#' : '';
                     // Bower uses the ~ range specifier for new installs
-                    jsonEndpoint[target.name] = '~' + target.pkgMeta.version;
+                    jsonEndpoint[target.name] = src + '~' + target.pkgMeta.version;
 
                     if (that._options.saveDev && mout.object.has(that._json, 'devDependencies.' + target.name)) {
                         that._json.devDependencies = mout.object.mixIn(that._json.devDependencies || {}, jsonEndpoint);

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -41,6 +41,21 @@ describe('bower install', function () {
 
     var gitPackage = new helpers.TempDir();
 
+    gitPackage.prepareGit({
+        '1.0.0': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '1.0.0'
+        },
+        '1.0.1': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '1.0.1'
+        }
+    });
+
     it('writes to bower.json if --save flag is used', function () {
         mainPackage.prepare();
 
@@ -250,20 +265,6 @@ describe('bower install', function () {
   });
 
     it('works for git repositories', function () {
-        gitPackage.prepareGit({
-            '1.0.0': {
-                'bower.json': {
-                    name: 'package'
-                },
-                'version.txt': '1.0.0'
-            },
-            '1.0.1': {
-                'bower.json': {
-                    name: 'package'
-                },
-                'version.txt': '1.0.1'
-            }
-        });
 
         tempDir.prepare({
             'bower.json': {
@@ -379,10 +380,10 @@ describe('bower install', function () {
           undefined,
           { proxy: 'http://dummy.local/' }
         ])
-    .fail(function(error) {
-        expect(error.message).to.equal('Status code of 500');
-        done();
-    });
+        .fail(function(error) {
+            expect(error.message).to.equal('Status code of 500');
+            done();
+        });
     });
 
 
@@ -397,4 +398,147 @@ describe('bower install', function () {
             expect(error.code).to.equal('ENOTDIR');
         });
     });
+
+    it('installs only the specified dependencies', function() {
+        var package4 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package3'
+            }
+        }).prepare();
+
+        var package3 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package3'
+            }
+        }).prepare();
+
+        var package2 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package2'
+            }
+        }).prepare();
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path,
+                    package3: package3.path,
+                    package4: package4.path
+                }
+            }
+        });
+
+        return helpers.run(install, [[package2.path, package3.path]]).then(function() {
+            expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
+            expect(tempDir.exists('bower_components/package3/bower.json')).to.equal(true);
+            expect(tempDir.exists('bower_components/package4')).to.equal(false);
+        });
+
+    });
+
+    it('installs sub deps of only the specified packages', function() {
+      var package3 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package3',
+              dependencies: {
+                  package: gitPackage.path + '#~1.0.1'
+              }
+          }
+      }).prepare();
+
+      var package2 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package2',
+              dependencies: {
+                  package: gitPackage.path + '#1.0.0'
+              }
+          }
+      }).prepare();
+
+      tempDir.prepare({
+          'bower.json': {
+              name: 'test',
+              dependencies: {
+                  package2: package2.path,
+                  package3: package3.path
+              }
+          }
+      });
+
+      return helpers.run(install, [
+          [package2.path]
+      ]).then(function() {
+          expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
+      });
+
+  });
+
+    it('doesn\'t update other deps when installing a specified dep', function() {
+      var package2 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package2',
+              version: '1.2.3'
+          }
+      }).prepare();
+
+      var package3 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package3',
+              version: '4.5.6'
+          }
+      }).prepare();
+
+      tempDir.prepare({
+          'bower.json': {
+              name: 'test',
+              dependencies: {
+                  package2: package2.path,
+                  package3: package3.path
+              }
+          }
+      });
+
+      // Install both dependencies, they should equal the latest release matching
+      // the ranges above.
+      return helpers.run(install).then(function() {
+          expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.2.3');
+          expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.5.6');
+          // Override first dep with older version
+          package2 = new helpers.TempDir({
+              'bower.json': {
+                  name: 'package2',
+                  version: '1.0.0'
+              }
+          }).prepare();
+          return helpers.run(install, [
+              [package2.path]
+          ]).then(function() {
+              expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.0.0');
+              expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.5.6');
+              // Override second dep with older version, the first dep should remain old
+              // and *not* get updated.
+              package2 = new helpers.TempDir({
+                  'bower.json': {
+                      name: 'package2',
+                      version: '1.2.3'
+                  }
+              }).prepare();
+              package3 = new helpers.TempDir({
+                  'bower.json': {
+                      name: 'package3',
+                      version: '4.0.0'
+                  }
+              }).prepare();
+              return helpers.run(install, [
+                  [package3.path]
+              ]).then(function() {
+                  expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.0.0');
+                  expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.0.0');
+              });
+          });
+      });
+
+  });
+
 });

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -3,34 +3,40 @@ var helpers = require('../helpers');
 var nock = require('nock');
 var fs = require('../../lib/util/fs');
 
-describe('bower install', function () {
+describe('bower install', function() {
 
     var tempDir = new helpers.TempDir();
 
-    var install = helpers.command('install', { cwd: tempDir.path });
+    var install = helpers.command('install', {
+        cwd: tempDir.path
+    });
 
     it('correctly reads arguments', function() {
         expect(install.readOptions(['jquery', 'angular', '-F', '-p', '-S', '-D', '-E']))
-    .to.eql([['jquery', 'angular'], {
-        forceLatest: true,
-        production: true,
-        save: true,
-        saveDev: true,
-        saveExact: true
-    }]);
+            .to.eql([
+                ['jquery', 'angular'], {
+                    forceLatest: true,
+                    production: true,
+                    save: true,
+                    saveDev: true,
+                    saveExact: true
+                }
+            ]);
     });
 
     it('correctly reads long arguments', function() {
         expect(install.readOptions([
-          'jquery', 'angular',
-          '--force-latest', '--production', '--save', '--save-dev', '--save-exact'
-    ])).to.eql([['jquery', 'angular'], {
-        forceLatest: true,
-        production: true,
-        save: true,
-        saveDev: true,
-        saveExact: true
-    }]);
+            'jquery', 'angular',
+            '--force-latest', '--production', '--save', '--save-dev', '--save-exact'
+        ])).to.eql([
+            ['jquery', 'angular'], {
+                forceLatest: true,
+                production: true,
+                save: true,
+                saveDev: true,
+                saveExact: true
+            }
+        ]);
     });
 
     var mainPackage = new helpers.TempDir({
@@ -56,7 +62,7 @@ describe('bower install', function () {
         }
     });
 
-    it('writes to bower.json if --save flag is used', function () {
+    it('writes to bower.json if --save flag is used', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -65,12 +71,16 @@ describe('bower install', function () {
             }
         });
 
-        return helpers.run(install, [[mainPackage.path], { save: true }]).then(function() {
+        return helpers.run(install, [
+            [mainPackage.path], {
+                save: true
+            }
+        ]).then(function() {
             expect(tempDir.read('bower.json')).to.contain('dependencies');
         });
     });
 
-    it('writes an exact version number to dependencies in bower.json if --save --save-exact flags are used', function () {
+    it('writes an exact version number to dependencies in bower.json if --save --save-exact flags are used', function() {
         mainPackage.prepare({
             'bower.json': {
                 name: 'package',
@@ -85,14 +95,16 @@ describe('bower install', function () {
         });
 
         return helpers.run(install, [
-          [mainPackage.path],
-          { saveExact: true, save: true }
-    ]).then(function() {
-        expect(tempDir.readJson('bower.json').dependencies.package).to.equal(mainPackage.path + '#1.2.3');
-    });
+            [mainPackage.path], {
+                saveExact: true,
+                save: true
+            }
+        ]).then(function() {
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(mainPackage.path + '#1.2.3');
+        });
     });
 
-    it('writes an exact version number to devDependencies in bower.json if --save-dev --save-exact flags are used', function () {
+    it('writes an exact version number to devDependencies in bower.json if --save-dev --save-exact flags are used', function() {
         mainPackage.prepare({
             'bower.json': {
                 name: 'package',
@@ -107,18 +119,24 @@ describe('bower install', function () {
         });
 
         return helpers.run(install, [
-          [mainPackage.path],
-          { saveExact: true, saveDev: true }
-    ]).then(function() {
-        expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(mainPackage.path + '#0.1.0');
-    });
+            [mainPackage.path], {
+                saveExact: true,
+                saveDev: true
+            }
+        ]).then(function() {
+            expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(mainPackage.path + '#0.1.0');
+        });
     });
 
-    it('reads .bowerrc from cwd', function () {
-        mainPackage.prepare({ foo: 'bar' });
+    it('reads .bowerrc from cwd', function() {
+        mainPackage.prepare({
+            foo: 'bar'
+        });
 
         tempDir.prepare({
-            '.bowerrc': { directory: 'assets' },
+            '.bowerrc': {
+                directory: 'assets'
+            },
             'bower.json': {
                 name: 'test',
                 dependencies: {
@@ -132,7 +150,7 @@ describe('bower install', function () {
         });
     });
 
-    it('runs preinstall hook', function () {
+    it('runs preinstall hook', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -154,7 +172,7 @@ describe('bower install', function () {
         });
     });
 
-    it('runs preinstall hook', function () {
+    it('runs preinstall hook', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -177,7 +195,7 @@ describe('bower install', function () {
     });
 
     // To be discussed, but that's the implementation now
-    it('does not run hooks if nothing is installed', function () {
+    it('does not run hooks if nothing is installed', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test'
@@ -195,7 +213,7 @@ describe('bower install', function () {
         });
     });
 
-    it('runs postinstall after bower.json is written', function () {
+    it('runs postinstall after bower.json is written', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -209,12 +227,16 @@ describe('bower install', function () {
             }
         });
 
-        return helpers.run(install, [[mainPackage.path], { save: true }]).then(function() {
+        return helpers.run(install, [
+            [mainPackage.path], {
+                save: true
+            }
+        ]).then(function() {
             expect(tempDir.read('hook.txt')).to.contain('dependencies');
         });
     });
 
-    it('display the output of hook scripts', function (next) {
+    it('display the output of hook scripts', function(next) {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -232,39 +254,38 @@ describe('bower install', function () {
         });
         var lastAction = null;
 
-        helpers.run(install).logger.intercept(function (log) {
+        helpers.run(install).logger.intercept(function(log) {
             if (log.level === 'action') {
                 lastAction = log;
             }
-        }).on('end', function () {
+        }).on('end', function() {
             expect(lastAction.message).to.be('foobar');
             next();
         });
     });
 
-    it('skips components not installed by bower', function () {
-      mainPackage.prepare({
-          '.git': {} //Make a dummy file instead of using slower gitPrepare()
-      });
+    it('skips components not installed by bower', function() {
+        mainPackage.prepare({
+            '.git': {} //Make a dummy file instead of using slower gitPrepare()
+        });
 
-      tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package: mainPackage.path
-              }
-          }
-      });
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package: mainPackage.path
+                }
+            }
+        });
 
-      return helpers.run(install).then(function() {
-          var packageFiles = fs.readdirSync(mainPackage.path);
-          //presence of .git file implies folder was not overwritten
-          expect(packageFiles).to.contain('.git');
-      });
+        return helpers.run(install).then(function() {
+            var packageFiles = fs.readdirSync(mainPackage.path);
+            //presence of .git file implies folder was not overwritten
+            expect(packageFiles).to.contain('.git');
+        });
+    });
 
-  });
-
-    it('works for git repositories', function () {
+    it('works for git repositories', function() {
 
         tempDir.prepare({
             'bower.json': {
@@ -314,7 +335,6 @@ describe('bower install', function () {
             expect(tempDir.exists('bower_components/package')).to.be(false);
             expect(tempDir.exists('bower_components/package2')).to.be(true);
         });
-
     });
 
     it('does not install ignored dependencies if run multiple times', function() {
@@ -352,10 +372,9 @@ describe('bower install', function () {
                 expect(tempDir.exists('bower_components/package2')).to.be(true);
             });
         });
-
     });
 
-    it('recognizes proxy option in config', function (done) {
+    it('recognizes proxy option in config', function(done) {
         this.timeout(10000);
 
         tempDir.prepare({
@@ -372,22 +391,23 @@ describe('bower install', function () {
         });
 
         nock('http://dummy.local')
-          .get('http://github.com/yahoo/pure/archive/v0.6.0.tar.gz')
-          .reply(500);
+            .get('http://github.com/yahoo/pure/archive/v0.6.0.tar.gz')
+            .reply(500);
 
         return helpers.run(install, [
-          undefined,
-          undefined,
-          { proxy: 'http://dummy.local/' }
-        ])
-        .fail(function(error) {
-            expect(error.message).to.equal('Status code of 500');
-            done();
-        });
+                undefined,
+                undefined, {
+                    proxy: 'http://dummy.local/'
+                }
+            ])
+            .fail(function(error) {
+                expect(error.message).to.equal('Status code of 500');
+                done();
+            });
     });
 
 
-    it('errors if the components directory is not a directory', function () {
+    it('errors if the components directory is not a directory', function() {
         tempDir.prepare({
             '.bowerrc': {
                 directory: '.bowerrc'
@@ -402,7 +422,7 @@ describe('bower install', function () {
     it('installs only the specified dependencies', function() {
         var package4 = new helpers.TempDir({
             'bower.json': {
-                name: 'package3'
+                name: 'package4'
             }
         }).prepare();
 
@@ -434,111 +454,108 @@ describe('bower install', function () {
             expect(tempDir.exists('bower_components/package3/bower.json')).to.equal(true);
             expect(tempDir.exists('bower_components/package4')).to.equal(false);
         });
-
     });
 
     it('installs sub deps of only the specified packages', function() {
-      var package3 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package3',
-              dependencies: {
-                  package: gitPackage.path + '#~1.0.1'
-              }
-          }
-      }).prepare();
+        var package3 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package3',
+                dependencies: {
+                    package: gitPackage.path + '#~1.0.1'
+                }
+            }
+        }).prepare();
 
-      var package2 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package2',
-              dependencies: {
-                  package: gitPackage.path + '#1.0.0'
-              }
-          }
-      }).prepare();
+        var package2 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package2',
+                dependencies: {
+                    package: gitPackage.path + '#1.0.0'
+                }
+            }
+        }).prepare();
 
-      tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package2: package2.path,
-                  package3: package3.path
-              }
-          }
-      });
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path,
+                    package3: package3.path
+                }
+            }
+        });
 
-      return helpers.run(install, [
-          [package2.path]
-      ]).then(function() {
-          expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
-      });
-
-  });
+        return helpers.run(install, [[package2.path]]).then(function() {
+            expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
+        });
+    });
 
     it('doesn\'t update other deps when installing a specified dep', function() {
-      var package2 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package2',
-              version: '1.2.3'
-          }
-      }).prepare();
+        var package2 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package2',
+                version: '1.2.3'
+            }
+        }).prepare();
 
-      var package3 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package3',
-              version: '4.5.6'
-          }
-      }).prepare();
+        var package3 = new helpers.TempDir({
+            'bower.json': {
+                name: 'package3',
+                version: '4.5.6'
+            }
+        }).prepare();
 
-      tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package2: package2.path,
-                  package3: package3.path
-              }
-          }
-      });
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path,
+                    package3: package3.path
+                }
+            }
+        });
 
-      // Install both dependencies, they should equal the latest release matching
-      // the ranges above.
-      return helpers.run(install).then(function() {
-          expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.2.3');
-          expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.5.6');
-          // Override first dep with older version
-          package2 = new helpers.TempDir({
-              'bower.json': {
-                  name: 'package2',
-                  version: '1.0.0'
-              }
-          }).prepare();
-          return helpers.run(install, [
-              [package2.path]
-          ]).then(function() {
-              expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.0.0');
-              expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.5.6');
-              // Override second dep with older version, the first dep should remain old
-              // and *not* get updated.
-              package2 = new helpers.TempDir({
-                  'bower.json': {
-                      name: 'package2',
-                      version: '1.2.3'
-                  }
-              }).prepare();
-              package3 = new helpers.TempDir({
-                  'bower.json': {
-                      name: 'package3',
-                      version: '4.0.0'
-                  }
-              }).prepare();
-              return helpers.run(install, [
-                  [package3.path]
-              ]).then(function() {
-                  expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.0.0');
-                  expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.0.0');
-              });
-          });
-      });
+        // Install both dependencies, they should equal the latest release matching
+        // the ranges above.
+        return helpers.run(install).then(function() {
 
-  });
+            expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.2.3');
+            expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.5.6');
 
+            // Override first dep with older version
+            package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2',
+                    version: '1.0.0'
+                }
+            }).prepare();
+
+            return helpers.run(install, [[package2.path]]).then(function() {
+
+                expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.0.0');
+                expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.5.6');
+
+                // Override second dep with older version, the first dep should remain old
+                // and *not* get updated.
+                package2 = new helpers.TempDir({
+                    'bower.json': {
+                        name: 'package2',
+                        version: '1.2.3'
+                    }
+                }).prepare();
+
+                package3 = new helpers.TempDir({
+                    'bower.json': {
+                        name: 'package3',
+                        version: '4.0.0'
+                    }
+                }).prepare();
+
+                return helpers.run(install, [[package3.path]]).then(function() {
+                    expect(tempDir.readJson('bower_components/package2/.bower.json').version).to.equal('1.0.0');
+                    expect(tempDir.readJson('bower_components/package3/.bower.json').version).to.equal('4.0.0');
+                });
+            });
+        });
+    });
 });

--- a/test/commands/update.js
+++ b/test/commands/update.js
@@ -3,11 +3,12 @@ var object = require('mout').object;
 var semver = require('semver');
 
 var helpers = require('../helpers');
+var rimraf = require('../../lib/util/rimraf');
 var updateCmd = helpers.command('update');
 var commands = helpers.require('lib/index').commands;
 
 describe('bower update', function () {
-    this.timeout(10000);
+
     var tempDir = new helpers.TempDir();
 
     var subPackage = new helpers.TempDir({
@@ -17,8 +18,16 @@ describe('bower update', function () {
     }).prepare();
 
     var gitPackage = new helpers.TempDir();
+    var gitPackage2 = new helpers.TempDir();
+    var gitPackage3 = new helpers.TempDir();
 
     gitPackage.prepareGit({
+        '0.1.1': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '0.9.0'
+        },
         '1.0.0': {
             'bower.json': {
                 name: 'package'
@@ -33,6 +42,36 @@ describe('bower update', function () {
                 }
             },
             'version.txt': '1.0.1'
+        }
+    });
+
+    gitPackage2.prepareGit({
+        '2.0.0': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '2.0.0'
+        },
+        '2.0.1': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '2.0.1'
+        }
+    });
+
+    gitPackage3.prepareGit({
+        '3.0.0': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '3.0.0'
+        },
+        '3.0.1': {
+            'bower.json': {
+                name: 'package'
+            },
+            'version.txt': '3.0.1'
         }
     });
 
@@ -265,6 +304,101 @@ describe('bower update', function () {
         });
     });
 
+    it('updates only the specified packages', function() {
+        var package4 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package4'
+          }
+      }).prepare();
+
+        var package3 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package3'
+          }
+      }).prepare();
+
+        var package2 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package2'
+          }
+      }).prepare();
+
+        tempDir.prepare({
+          'bower.json': {
+              name: 'test',
+              dependencies: {
+                  package2: package2.path,
+                  package3: package3.path,
+                  package4: package4.path
+              }
+          }
+      });
+
+        return install().then(function() {
+
+            rimraf.sync(tempDir.path + '/bower_components/');
+
+            return update(['package4']).then(function() {
+              expect(tempDir.exists('bower_components/package2')).to.equal(false);
+              expect(tempDir.exists('bower_components/package3')).to.equal(false);
+              expect(tempDir.exists('bower_components/package4/bower.json')).to.equal(true);
+
+              rimraf.sync(tempDir.path + '/bower_components/');
+
+              return update(['package2', 'package3']).then(function() {
+                  expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
+                  expect(tempDir.exists('bower_components/package3/bower.json')).to.equal(true);
+                  expect(tempDir.exists('bower_components/package4')).to.equal(false);
+              });
+
+          });
+
+        });
+
+    });
+
+    it('updates sub deps of only the specified packages', function() {
+        var package3 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package3',
+              dependencies: {
+                  package: gitPackage.path + '#~1.0.0'
+              }
+          }
+      }).prepare();
+
+        var package2 = new helpers.TempDir({
+          'bower.json': {
+              name: 'package2',
+              dependencies: {
+                  package: gitPackage2.path + '#~2.0.0'
+              }
+          }
+      }).prepare();
+
+        tempDir.prepare({
+          'bower.json': {
+              name: 'test',
+              dependencies: {
+                  package2: package2.path,
+                  package3: package3.path
+              }
+          }
+      });
+
+        return install([package2.path]).then(function() {
+          expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('2.0.1');
+
+          rimraf.sync(tempDir.path + '/bower_components/');
+
+          return update(['package3']).then(function() {
+              expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.1');
+          });
+
+      });
+
+    });
+
     it('doesn\'t update extraneous packages', function () {
         tempDir.prepare({
             'bower.json': {
@@ -272,12 +406,12 @@ describe('bower update', function () {
             }
         });
 
-        return install(['underscore#1.5.0']).then(function() {
+        return install(['package=' + gitPackage.path + '#1.0.0']).then(function() {
 
-            expect(tempDir.readJson('bower_components/underscore/package.json').version).to.equal('1.5.0');
+            expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
 
             return update(null, {save: true}).then(function() {
-                expect(tempDir.readJson('bower_components/underscore/package.json').version).to.equal('1.5.0');
+                expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
                 expect(tempDir.readJson('bower.json')).to.not.have.property('dependencies');
             });
         });
@@ -288,17 +422,17 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    underscore: '~1.5.0'
+                    package: gitPackage.path + '#~1.0.0'
                 }
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('~1.5.0');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.0');
 
             return update(null, {save: true}).then(function() {
-                expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('~1.5.2');
+                expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.1');
             });
 
         });
@@ -309,17 +443,17 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 devDependencies: {
-                    underscore: '~1.5.0'
+                    package: gitPackage.path + '#~1.0.0'
                 }
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').devDependencies.underscore).to.equal('~1.5.0');
+            expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(gitPackage.path + '#~1.0.0');
 
             return update(null, {saveDev: true}).then(function() {
-                expect(tempDir.readJson('bower.json').devDependencies.underscore).to.equal('~1.5.2');
+                expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(gitPackage.path + '#~1.0.1');
             });
 
         });
@@ -330,17 +464,18 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    underscore: '*'
+                    package: gitPackage.path + '#*'
                 }
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('*');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#*');
 
             return update(null, {save: true}).then(function() {
-                var version = semver.gte(tempDir.readJson('bower.json').dependencies.underscore.replace('~', ''), '1.8.3');
+                var version = tempDir.readJson('bower.json').dependencies.package.replace(gitPackage.path + '#~', '');
+                version = semver.gte(version, '1.0.1');
                 expect(version).to.be.ok();
             });
 
@@ -352,27 +487,27 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    underscore: '~1.5.0',
-                    lodash: '~1.0.0'
+                    package: gitPackage.path + '#~1.0.0',
+                    package2: gitPackage2.path + '#~2.0.0'
                 },
                 devDependencies: {
-                    neat: '~1.5.0'
+                    package3: gitPackage3.path + '#~3.0.0'
                 },
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('~1.5.0');
-            expect(tempDir.readJson('bower.json').dependencies.lodash).to.equal('~1.0.0');
-            expect(tempDir.readJson('bower.json').devDependencies.neat).to.equal('~1.5.0');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.0');
+            expect(tempDir.readJson('bower.json').dependencies.package2).to.equal(gitPackage2.path + '#~2.0.0');
+            expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.0');
 
             return update(null, {save: true}).then(function() {
                 // Normal deps should have changed
-                expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('~1.5.2');
-                expect(tempDir.readJson('bower.json').dependencies.lodash).to.equal('~1.0.2');
+                expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.1');
+                expect(tempDir.readJson('bower.json').dependencies.package2).to.equal(gitPackage2.path + '#~2.0.1');
                 // Dev deps should not have changed
-                expect(tempDir.readJson('bower.json').devDependencies.neat).to.equal('~1.5.0');
+                expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.0');
             });
 
         });
@@ -383,27 +518,27 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    neat: '~1.5.0'
+                    package: gitPackage.path + '#~1.0.0'
                 },
                 devDependencies: {
-                    underscore: '~1.5.0',
-                    lodash: '~1.0.0'
-                }
+                    package2: gitPackage2.path + '#~2.0.0',
+                    package3: gitPackage3.path + '#~3.0.0'
+                },
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.neat).to.equal('~1.5.0');
-            expect(tempDir.readJson('bower.json').devDependencies.underscore).to.equal('~1.5.0');
-            expect(tempDir.readJson('bower.json').devDependencies.lodash).to.equal('~1.0.0');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.0');
+            expect(tempDir.readJson('bower.json').devDependencies.package2).to.equal(gitPackage2.path + '#~2.0.0');
+            expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.0');
 
             return update(null, {saveDev: true}).then(function() {
                 // Normal deps should not have changed
-                expect(tempDir.readJson('bower.json').dependencies.neat).to.equal('~1.5.0');
+                expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.0');
                 // Dev deps should have changed
-                expect(tempDir.readJson('bower.json').devDependencies.underscore).to.equal('~1.5.2');
-                expect(tempDir.readJson('bower.json').devDependencies.lodash).to.equal('~1.0.2');
+                expect(tempDir.readJson('bower.json').devDependencies.package2).to.equal(gitPackage2.path + '#~2.0.1');
+                expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.1');
             });
 
         });
@@ -414,17 +549,17 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    underscore: '^0.1.0'
+                    package: gitPackage.path + '#^0.1.0'
                 }
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('^0.1.0');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#^0.1.0');
 
             return update(null, {save: true}).then(function() {
-                expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('~0.1.1');
+                expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~0.1.1');
             });
 
         });
@@ -435,17 +570,17 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    lodash: '^1.0.0'
+                    package: gitPackage.path + '#^1.0.0'
                 }
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.lodash).to.equal('^1.0.0');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#^1.0.0');
 
             return update(null, {save: true}).then(function() {
-                expect(tempDir.readJson('bower.json').dependencies.lodash).to.equal('~1.3.1');
+                expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.1');
             });
 
         });
@@ -456,17 +591,17 @@ describe('bower update', function () {
             'bower.json': {
                 name: 'test',
                 dependencies: {
-                    underscore: '1.5.0'
+                    package: gitPackage.path + '#1.0.0'
                 }
             }
         });
 
         return install().then(function() {
 
-            expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('1.5.0');
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#1.0.0');
 
             return update(null, {save: true}).then(function() {
-                expect(tempDir.readJson('bower.json').dependencies.underscore).to.equal('1.5.0');
+                expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#1.0.0');
             });
 
         });

--- a/test/commands/update.js
+++ b/test/commands/update.js
@@ -7,7 +7,7 @@ var rimraf = require('../../lib/util/rimraf');
 var updateCmd = helpers.command('update');
 var commands = helpers.require('lib/index').commands;
 
-describe('bower update', function () {
+describe('bower update', function() {
 
     var tempDir = new helpers.TempDir();
 
@@ -107,15 +107,17 @@ describe('bower update', function () {
 
     it('correctly reads arguments', function() {
         expect(updateCmd.readOptions(['jquery', '-F', '-p', '-S', '-D']))
-        .to.eql([['jquery'], {
-            forceLatest: true,
-            production: true,
-            save: true,
-            saveDev: true
-        }]);
+            .to.eql([
+                ['jquery'], {
+                    forceLatest: true,
+                    production: true,
+                    save: true,
+                    saveDev: true
+                }
+            ]);
     });
 
-    it('install missing packages', function () {
+    it('install missing packages', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -135,77 +137,76 @@ describe('bower update', function () {
 
     it('does not install ignored dependencies', function() {
         var package3 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package3'
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package3'
+            }
+        }).prepare();
 
         var package2 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package2',
-              dependencies: {
-                  package3: package3.path
-              }
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package2',
+                dependencies: {
+                    package3: package3.path
+                }
+            }
+        }).prepare();
 
         tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package2: package2.path
-              }
-          },
-          '.bowerrc': {
-              ignoredDependencies: ['package3']
-          }
-      });
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path
+                }
+            },
+            '.bowerrc': {
+                ignoredDependencies: ['package3']
+            }
+        });
 
         return update().then(function() {
-          expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
-          expect(tempDir.exists('bower_components/package3')).to.equal(false);
-      });
-
+            expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
+            expect(tempDir.exists('bower_components/package3')).to.equal(false);
+        });
     });
 
     it('does not install ignored dependencies if run multiple times', function() {
         var package3 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package3'
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package3'
+            }
+        }).prepare();
 
         var package2 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package2',
-              dependencies: {
-                  package3: package3.path
-              }
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package2',
+                dependencies: {
+                    package3: package3.path
+                }
+            }
+        }).prepare();
 
         tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package2: package2.path
-              }
-          },
-          '.bowerrc': {
-              ignoredDependencies: ['package3']
-          }
-      });
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path
+                }
+            },
+            '.bowerrc': {
+                ignoredDependencies: ['package3']
+            }
+        });
 
         return update().then(function() {
-          return update().then(function() {
-              expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
-              expect(tempDir.exists('bower_components/package3')).to.equal(false);
-          });
-      });
+            return update().then(function() {
+                expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
+                expect(tempDir.exists('bower_components/package3')).to.equal(false);
+            });
+        });
 
     });
 
-    it('runs preinstall hook when installing missing package', function () {
+    it('runs preinstall hook when installing missing package', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -227,7 +228,7 @@ describe('bower update', function () {
         });
     });
 
-    it('runs postinstall hook when installing missing package', function () {
+    it('runs postinstall hook when installing missing package', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -249,7 +250,7 @@ describe('bower update', function () {
         });
     });
 
-    it('doesn\'t runs postinstall when no package is update', function () {
+    it('doesn\'t runs postinstall when no package is update', function() {
         mainPackage.prepare();
 
         tempDir.prepare({
@@ -275,7 +276,7 @@ describe('bower update', function () {
         });
     });
 
-    it('updates a package', function () {
+    it('updates a package', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -306,100 +307,95 @@ describe('bower update', function () {
 
     it('updates only the specified packages', function() {
         var package4 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package4'
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package4'
+            }
+        }).prepare();
 
         var package3 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package3'
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package3'
+            }
+        }).prepare();
 
         var package2 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package2'
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package2'
+            }
+        }).prepare();
 
         tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package2: package2.path,
-                  package3: package3.path,
-                  package4: package4.path
-              }
-          }
-      });
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path,
+                    package3: package3.path,
+                    package4: package4.path
+                }
+            }
+        });
 
         return install().then(function() {
 
             rimraf.sync(tempDir.path + '/bower_components/');
 
             return update(['package4']).then(function() {
-              expect(tempDir.exists('bower_components/package2')).to.equal(false);
-              expect(tempDir.exists('bower_components/package3')).to.equal(false);
-              expect(tempDir.exists('bower_components/package4/bower.json')).to.equal(true);
+                expect(tempDir.exists('bower_components/package2')).to.equal(false);
+                expect(tempDir.exists('bower_components/package3')).to.equal(false);
+                expect(tempDir.exists('bower_components/package4/bower.json')).to.equal(true);
 
-              rimraf.sync(tempDir.path + '/bower_components/');
+                rimraf.sync(tempDir.path + '/bower_components/');
 
-              return update(['package2', 'package3']).then(function() {
-                  expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
-                  expect(tempDir.exists('bower_components/package3/bower.json')).to.equal(true);
-                  expect(tempDir.exists('bower_components/package4')).to.equal(false);
-              });
-
-          });
-
+                return update(['package2', 'package3']).then(function() {
+                    expect(tempDir.exists('bower_components/package2/bower.json')).to.equal(true);
+                    expect(tempDir.exists('bower_components/package3/bower.json')).to.equal(true);
+                    expect(tempDir.exists('bower_components/package4')).to.equal(false);
+                });
+            });
         });
-
     });
 
     it('updates sub deps of only the specified packages', function() {
         var package3 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package3',
-              dependencies: {
-                  package: gitPackage.path + '#~1.0.0'
-              }
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package3',
+                dependencies: {
+                    package: gitPackage.path + '#~1.0.0'
+                }
+            }
+        }).prepare();
 
         var package2 = new helpers.TempDir({
-          'bower.json': {
-              name: 'package2',
-              dependencies: {
-                  package: gitPackage2.path + '#~2.0.0'
-              }
-          }
-      }).prepare();
+            'bower.json': {
+                name: 'package2',
+                dependencies: {
+                    package: gitPackage2.path + '#~2.0.0'
+                }
+            }
+        }).prepare();
 
         tempDir.prepare({
-          'bower.json': {
-              name: 'test',
-              dependencies: {
-                  package2: package2.path,
-                  package3: package3.path
-              }
-          }
-      });
+            'bower.json': {
+                name: 'test',
+                dependencies: {
+                    package2: package2.path,
+                    package3: package3.path
+                }
+            }
+        });
 
         return install([package2.path]).then(function() {
-          expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('2.0.1');
+            expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('2.0.1');
 
-          rimraf.sync(tempDir.path + '/bower_components/');
+            rimraf.sync(tempDir.path + '/bower_components/');
 
-          return update(['package3']).then(function() {
-              expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.1');
-          });
-
-      });
-
+            return update(['package3']).then(function() {
+                expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.1');
+            });
+        });
     });
 
-    it('doesn\'t update extraneous packages', function () {
+    it('doesn\'t update extraneous packages', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test'
@@ -410,14 +406,16 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 expect(tempDir.readJson('bower_components/package/.bower.json').version).to.equal('1.0.0');
                 expect(tempDir.readJson('bower.json')).to.not.have.property('dependencies');
             });
         });
     });
 
-    it('updates bower.json dep after updating with --save flag', function () {
+    it('updates bower.json dep after updating with --save flag', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -431,14 +429,15 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.0');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.1');
             });
-
         });
     });
 
-    it('updates bower.json dev dep after updating with --save-dev flag', function () {
+    it('updates bower.json dev dep after updating with --save-dev flag', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -452,14 +451,15 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(gitPackage.path + '#~1.0.0');
 
-            return update(null, {saveDev: true}).then(function() {
+            return update(null, {
+                saveDev: true
+            }).then(function() {
                 expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(gitPackage.path + '#~1.0.1');
             });
-
         });
     });
 
-    it('replaces "any" range with latest version', function () {
+    it('replaces "any" range with latest version', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -473,16 +473,17 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#*');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 var version = tempDir.readJson('bower.json').dependencies.package.replace(gitPackage.path + '#~', '');
                 version = semver.gte(version, '1.0.1');
                 expect(version).to.be.ok();
             });
-
         });
     });
 
-    it('updates multiple components in bower.json after updating with --save flag', function () {
+    it('updates multiple components in bower.json after updating with --save flag', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -502,18 +503,19 @@ describe('bower update', function () {
             expect(tempDir.readJson('bower.json').dependencies.package2).to.equal(gitPackage2.path + '#~2.0.0');
             expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.0');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 // Normal deps should have changed
                 expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.1');
                 expect(tempDir.readJson('bower.json').dependencies.package2).to.equal(gitPackage2.path + '#~2.0.1');
                 // Dev deps should not have changed
                 expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.0');
             });
-
         });
     });
 
-    it('updates multiple components in bower.json after updating with --save-dev flag', function () {
+    it('updates multiple components in bower.json after updating with --save-dev flag', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -533,18 +535,19 @@ describe('bower update', function () {
             expect(tempDir.readJson('bower.json').devDependencies.package2).to.equal(gitPackage2.path + '#~2.0.0');
             expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.0');
 
-            return update(null, {saveDev: true}).then(function() {
+            return update(null, {
+                saveDev: true
+            }).then(function() {
                 // Normal deps should not have changed
                 expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.0');
                 // Dev deps should have changed
                 expect(tempDir.readJson('bower.json').devDependencies.package2).to.equal(gitPackage2.path + '#~2.0.1');
                 expect(tempDir.readJson('bower.json').devDependencies.package3).to.equal(gitPackage3.path + '#~3.0.1');
             });
-
         });
     });
 
-    it('correctly interprets semver range specifier pre-1.0', function () {
+    it('correctly interprets semver range specifier pre-1.0', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -558,14 +561,15 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#^0.1.0');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~0.1.1');
             });
-
         });
     });
 
-    it('correctly interprets semver range specifier post-1.0', function () {
+    it('correctly interprets semver range specifier post-1.0', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -579,14 +583,15 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#^1.0.0');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#~1.0.1');
             });
-
         });
     });
 
-    it('doesn\'t update bower.json if versions are identical', function () {
+    it('doesn\'t update bower.json if versions are identical', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -600,14 +605,15 @@ describe('bower update', function () {
 
             expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#1.0.0');
 
-            return update(null, {save: true}).then(function() {
+            return update(null, {
+                save: true
+            }).then(function() {
                 expect(tempDir.readJson('bower.json').dependencies.package).to.equal(gitPackage.path + '#1.0.0');
             });
-
         });
     });
 
-    it('does not install ignored dependencies when updating a package', function () {
+    it('does not install ignored dependencies when updating a package', function() {
         var package3 = new helpers.TempDir({
             'bower.json': {
                 name: 'package3'
@@ -671,7 +677,7 @@ describe('bower update', function () {
         });
     });
 
-    it('runs preinstall hook when updating a package', function () {
+    it('runs preinstall hook when updating a package', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',
@@ -703,7 +709,7 @@ describe('bower update', function () {
         });
     });
 
-    it('runs postinstall hook when updating a package', function () {
+    it('runs postinstall hook when updating a package', function() {
         tempDir.prepare({
             'bower.json': {
                 name: 'test',


### PR DESCRIPTION
Given:

```js
"dependencies": {
    "component-one": "~1.0.0",
    "component-two": "~1.0.0"
}
```

Running `bower update component-one` will update component-one *and* component-two. This is particularly problematic if you have dozens of dependencies because you'll be waiting for bower to download all of them when all you wanted was component-one. Running `bower install component-XYZ` does the same thing -- update every component.

This PR instructs the manager to only update the requested component(s).

General logic:

1. Store arguments passed to the install/update commands (the names of packages the user wants to install/update).
2. When it's time to fetch targets, only fetch targets that match the packages from step 1.
3. If no arguments were passed, fetch everything.

Related to #256, #924, #1770 and probably many other issues.

Feedback appreciated.