### PR TITLE
Prompt before listing all repos when running `bower search` without a query param

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,6 +1,7 @@
 var Q = require('q');
 var Logger = require('bower-logger');
 var config = require('../config');
+var cli = require('../util/cli');
 
 /**
  * Require commands only when called.
@@ -24,12 +25,31 @@ function commandFactory(id) {
     }
 
     function runFromArgv(argv) {
+        var commandArgs;
+        var errorForLogger;
+        var command = require(id);
+
+        try {
+            commandArgs = command.readOptions(argv);
+        }
+        catch (e) {
+            if (e.code === cli.READ_OPTIONS_ERROR_CODE) {
+                return null;
+            }
+            else {
+                // Delay raising the error until the logger is set up so the
+                // logger can handle it.
+                errorForLogger = e;
+            }
+        }
+
         return withLogger(function (logger) {
-            var command = require(id);
+            // Raise any non-read-options error so the logger can handle it.
+            if (errorForLogger) {
+                throw errorForLogger;
+            }
 
-            var commandArgs = command.readOptions(argv);
             commandArgs.unshift(logger);
-
             return command.apply(undefined, commandArgs);
         });
     }

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -2,6 +2,8 @@ var Q = require('q');
 var RegistryClient = require('bower-registry-client');
 var Tracker = require('../util/analytics').Tracker;
 var defaultConfig = require('../config');
+var bowerConfig = require('../../lib').config;
+var cli = require('../util/cli');
 
 function search(logger, name, config) {
     var registryClient;
@@ -14,21 +16,29 @@ function search(logger, name, config) {
     tracker = new Tracker(config);
     tracker.track('search', name);
 
-    // If no name was specified, list all packages
-    if (!name) {
-        return Q.nfcall(registryClient.list.bind(registryClient));
-    // Otherwise search it
-    } else {
+    // Search if the user has given a name query
+    if (name) {
         return Q.nfcall(registryClient.search.bind(registryClient), name);
+    }
+    // List all packages when in interactive mode + json enabled, and
+    // always when in non-interactive mode
+    else if (bowerConfig.json || !config.interactive) {
+        return Q.nfcall(registryClient.list.bind(registryClient));
     }
 }
 
 // -------------------
 
 search.readOptions = function (argv) {
-    var cli = require('../util/cli');
     var options = cli.readOptions(argv);
-    var name = options.argv.remain.slice(1).join(' ');
+    var terms = options.argv.remain.slice(1);
+
+    // When searching from the CLI, we expect at least one search term.
+    if (terms.length <= 0) {
+        throw cli.createReadOptionsError('search');
+    }
+
+    var name = terms.join(' ');
 
     return [name];
 };

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -1,6 +1,9 @@
 var mout = require('mout');
 var nopt = require('nopt');
 var renderers = require('../renderers');
+var createError = require('./createError');
+
+var READ_OPTIONS_ERROR_CODE = 'EREADOPTIONS';
 
 function readOptions(options, argv) {
     var types;
@@ -37,6 +40,16 @@ function readOptions(options, argv) {
     return parsedOptions;
 }
 
+/**
+ * Creates an error for the case where a command has trouble parsing command
+ * line options.
+ **/
+function createReadOptionsError(commandName) {
+    var errorString = commandName + ' syntax error';
+
+    return createError(errorString, READ_OPTIONS_ERROR_CODE);
+}
+
 function getRenderer(command, json, config) {
     if (config.json || json) {
         return new renderers.Json(command, config);
@@ -47,3 +60,6 @@ function getRenderer(command, json, config) {
 
 module.exports.readOptions = readOptions;
 module.exports.getRenderer = getRenderer;
+
+module.exports.createReadOptionsError = createReadOptionsError;
+module.exports.READ_OPTIONS_ERROR_CODE = READ_OPTIONS_ERROR_CODE;

--- a/test/commands/search.js
+++ b/test/commands/search.js
@@ -27,7 +27,9 @@ describe('bower search', function () {
         });
     });
 
-    it('lists all repositories if no query given', function () {
+    it('lists all repositories when no query given in non-interactive mode', function () {
+        var nonInteractiveConfig = { interactive: false };
+
         return Q.Promise(function(resolve) {
             var search = helpers.command('search', {
                 'bower-registry-client': function() {
@@ -37,8 +39,56 @@ describe('bower search', function () {
                 }
             });
 
-            helpers.run(search, [], {});
+            helpers.run(search, [null, nonInteractiveConfig]);
         });
     });
 
+    it('lists all repositories when no query given and config.json is enabled in interactive mode', function () {
+        // Set the json config globally as if it were entered on the command line
+        var bowerConfig = require('../../lib').config;
+        bowerConfig.json = true;
+
+        var interactiveConfig = { interactive: true };
+
+        return Q.Promise(function(resolve) {
+            var search = helpers.command('search', {
+                'bower-registry-client': function() {
+                    return {
+                        list: resolve
+                    };
+                }
+            });
+
+            helpers.run(search, [null, interactiveConfig]);
+        }).then(function() {
+            // Reset the global json config value
+            bowerConfig.json = false;
+        });
+    });
+
+    it('does not list any repositories in interactive mode if no query given and config.json is disabled', function (done) {
+        var interactiveConfig = { interactive: true };
+        return Q.Promise(function(resolve, reject) {
+            var search = helpers.command('search', {
+                'bower-registry-client': function() {
+                    return {
+                        list: reject
+                    };
+                }
+            });
+
+            helpers.run(search, [null, interactiveConfig]).then(function(loggerEndData) {
+                var commandResult = loggerEndData[0];
+                resolve(commandResult);
+            });
+        })
+        .then(function(commandResult) {
+            // No work should have been done, so no value should be returned.
+            expect(commandResult).to.be(undefined);
+        })
+        .catch(function() {
+            expect().fail('should not list repositories');
+        })
+        .done(done);
+    });
 });


### PR DESCRIPTION
# Description
This PR aims to address issue #2066 by warning the user before attempting to list all packages when using `bower search` with no query parameter.

## In interactive mode
When running `bower search` with no additional params, the user should see the following:
```
? Running search with no search term will list all bower packages and may take a while to complete. Continue? (Y/n)
```

If they confirm the action, the search will be performed. If they deny the action, `No results.` will be printed and they will be returned to their prompt.

## In non-interactive (programmatic mode)
The search will just be performed without any prompt.

## Tests
The PR includes tests that no prompt occurs in non-interactive mode (no prompt, just like it was before the PR), and tests that the full listing is generated in interactive mode if and only if the user agrees to continue past the warning.

## Note
This is my first PR to an open source project, and therefore my first to bower as well, so let me know if I'm doing something incorrectly.