### PR TITLE
Add info help message on no arg

### DIFF
--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -62,6 +62,10 @@ info.readOptions = function (argv) {
     var pkg = options.argv.remain[1];
     var property = options.argv.remain[2];
 
+	if (!(pkg || property)) {
+		throw cli.createReadOptionsError('info');
+	}
+
     return [pkg, property];
 };
 

--- a/test/commands/info.js
+++ b/test/commands/info.js
@@ -2,6 +2,7 @@ var expect = require('expect.js');
 
 var helpers = require('../helpers');
 var info = helpers.command('info');
+var Q = require('q');
 
 describe('bower info', function () {
 
@@ -48,5 +49,24 @@ describe('bower info', function () {
                 ]
             });
         });
+    });
+
+    it('shows help for info when no arg given', function (done) {
+        return Q.Promise(function(resolve, reject) {
+            var info = helpers.command('info');
+
+            helpers.run(info).then(function(loggerEndData) {
+                var commandResult = loggerEndData[0];
+                resolve(commandResult);
+            });
+        })
+        .then(function(commandResult) {
+            // No work should have been done, so no value should be returned.
+            expect(commandResult).to.be(undefined);
+        })
+        .catch(function() {
+            expect().fail('should list info');
+        })
+        .done(done);
     });
 });


### PR DESCRIPTION
Added info help message when no argument is input for `bower info`. All others throw errors already, info was the only one that had no output when no input arg was given. (as far as I could find)