### PR TITLE
Hide prerelease versions from `bower info`

### DIFF
--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -5,6 +5,7 @@ var archy = require('archy');
 var Q = require('q');
 var stringifyObject = require('stringify-object');
 var os = require('os');
+var semverUtils = require('semver-utils');
 var pkg = require(path.join(__dirname, '../..', 'package.json'));
 var template = require('../util/template');
 
@@ -209,6 +210,18 @@ StandardRenderer.prototype._info = function (data) {
 
     // Render the versions at the end
     if (includeVersions) {
+        data.hidePreReleases = false;
+        data.numPreReleases = 0;
+        // If output isn't verbose, hide prereleases
+        if (!this._config.verbose) {
+            data.versions = mout.array.filter(data.versions, function(val) {
+                if (!semverUtils.parse(val).build) {
+                    return true;
+                }
+                data.numPreReleases++;
+            });
+            data.hidePreReleases = !!data.numPreReleases;
+        }
         str += '\n' + template.render('std/info.std', data);
     }
 

--- a/lib/renderers/StandardRenderer.js
+++ b/lib/renderers/StandardRenderer.js
@@ -214,8 +214,9 @@ StandardRenderer.prototype._info = function (data) {
         data.numPreReleases = 0;
         // If output isn't verbose, hide prereleases
         if (!this._config.verbose) {
-            data.versions = mout.array.filter(data.versions, function(val) {
-                if (!semverUtils.parse(val).build) {
+            data.versions = mout.array.filter(data.versions, function(version) {
+                version = semverUtils.parse(version);
+                if (!version.release && !version.build) {
                     return true;
                 }
                 data.numPreReleases++;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "retry": "0.6.1",
     "rimraf": "^2.2.8",
     "semver": "^2.3.0",
+    "semver-utils": "^1.1.1",
     "shell-quote": "^1.4.2",
     "stringify-object": "^1.0.0",
     "tar-fs": "^1.4.1",

--- a/templates/std/info.std
+++ b/templates/std/info.std
@@ -5,6 +5,10 @@
 {{/versions}}
 {{/condense}}
 
+
+{{#if hidePreReleases}}
+Show {{numPreReleases}} additional prereleases with ‘bower info {{name}} --verbose’
+{{/if}}
 You can request info for a specific version with 'bower info {{name}}#<version>'
 {{else}}No versions available.
 {{/if}}

--- a/test/renderers/StandardRenderer.js
+++ b/test/renderers/StandardRenderer.js
@@ -613,7 +613,11 @@ describe('StandardRenderer', function () {
                 versions: [
                     '1.2.0',
                     '1.2.1',
-                    '1.2.2'
+                    '1.2.2',
+                    '1.2.3+build-1234',
+                    '1.2.8-build.2098+sha.cb9c0f2',
+                    '1.3.0-rc.5',
+                    '1.3.0-beta.18'
                 ]
             });
         }).spread(function(stdout, stderr) {
@@ -627,6 +631,48 @@ describe('StandardRenderer', function () {
                   - 1.2.0
                   - 1.2.1
                   - 1.2.2
+
+                Show 4 additional prereleases with ‘bower info foo --verbose’
+                You can request info for a specific version with 'bower info foo#<version>'
+
+            */}));
+        });
+    });
+
+    it('outputs full info command log with prereleases', function() {
+        return helpers.capture(function() {
+            var renderer = new StandardRenderer('info', { verbose: true });
+            renderer.end({
+                name: 'foo',
+                latest: {
+                    version: '1.2.3'
+                },
+                versions: [
+                    '1.2.0',
+                    '1.2.1',
+                    '1.2.2',
+                    '1.2.3+build-1234',
+                    '1.2.8-build.2098+sha.cb9c0f2',
+                    '1.3.0-rc.5',
+                    '1.3.0-beta.18'
+                ]
+            });
+        }).spread(function(stdout, stderr) {
+            expect(stdout).to.equal(multiline(function() {/*
+
+                {
+                  version: '1.2.3'
+                }
+
+                Available versions:
+                  - 1.2.0
+                  - 1.2.1
+                  - 1.2.2
+                  - 1.2.3+build-1234
+                  - 1.2.8-build.2098+sha.cb9c0f2
+                  - 1.3.0-rc.5
+                  - 1.3.0-beta.18
+
                 You can request info for a specific version with 'bower info foo#<version>'
 
             */}));


### PR DESCRIPTION
Hides prereleases behind the `--verbose` flag. Fixes #2081.

Current behavior:

```
$ bower info angular

{
  name: 'angular',
  version: '1.4.8',
  main: './angular.js',
  ignore: [],
  dependencies: {},
  homepage: 'https://github.com/angular/bower-angular'
}

Available versions:
  - 1.5.0-build.4422+sha.e94b37e
  - 1.5.0-build.4421+sha.6976d6d
  - 1.5.0-build.4420+sha.df6fade
  - 1.5.0-build.4419+sha.983b059
  - 1.5.0-build.4418+sha.983b059
  - 1.5.0-build.4417+sha.25e8c59
  - 1.5.0-build.4416+sha.6628b4f
  - 1.5.0-build.4415+sha.6e18b50
  - 1.5.0-build.4414+sha.77419cf
  - 1.5.0-build.4413+sha.193153c
  - 1.5.0-build.4412+sha.6a0686d
  - 1.5.0-build.4411+sha.6a0686d
  - 1.5.0-build.4410+sha.08c9a5e
  - 1.5.0-build.4409+sha.a72c12b
  - 1.5.0-build.4408+sha.73e3865
  - 1.5.0-build.4407+sha.b641181
  - 1.5.0-build.4406+sha.7ffb2d3
  - 1.5.0-build.4405+sha.023b777
  - 1.5.0-build.4404+sha.023b777
  - 1.5.0-build.4403+sha.0b5ecc6
  - 1.5.0-build.4402+sha.7ddbc9a
  - 1.5.0-build.4401+sha.b2a937d
  - 1.5.0-build.4400+sha.b2a937d
  - 1.5.0-build.4399+sha.98528be
  - 1.5.0-build.4398+sha.9190d4c
  - 1.5.0-build.4397+sha.d9ec995
  - 1.5.0-build.4396+sha.596af70
  - 1.5.0-build.4395+sha.1537651
  - 1.5.0-build.4394+sha.ab5824e
  - 1.5.0-build.4391+sha.a5ff651
  - 1.5.0-build.4390+sha.ccd47ec
  - 1.5.0-build.4389+sha.2e23a3c
  - 1.5.0-build.4388+sha.ca7f4a3
  - 1.5.0-build.4387+sha.898a3fd
  - 1.5.0-build.4386+sha.e527559
  - 1.5.0-build.4385+sha.78297d2
  - 1.5.0-build.4384+sha.e5e0884
  - 1.5.0-build.4383+sha.f5aa207
  - 1.5.0-build.4382+sha.4412fe2
  - 1.5.0-build.4381+sha.8088284
  - 1.5.0-build.4380+sha.25f1bba
  - 1.5.0-build.4379+sha.bd7b217
  - 1.5.0-build.4378+sha.b837fc3
  - 1.5.0-build.4377+sha.b837fc3
  - 1.5.0-build.4376+sha.aff74ec
  - 1.5.0-build.4375+sha.92bdd76
  - 1.5.0-build.4374+sha.39ebb06
  - 1.5.0-build.4373+sha.39ebb06
  - 1.5.0-build.4372+sha.9cf6b19
  - 1.5.0-build.4371+sha.4971ef1
  - 1.5.0-build.4370+sha.7c792f4
  - 1.5.0-build.4369+sha.4daafd3
  - 1.5.0-build.4368+sha.fe11265
  - 1.5.0-build.4367+sha.4ff6c85
  - 1.5.0-build.4366+sha.17715fa
  - 1.5.0-build.4365+sha.96288d0
  - 1.5.0-build.4364+sha.8be98e4
  - 1.5.0-build.4361+sha.15bfea8
  - 1.5.0-build.4360+sha.9b90c32
  - 1.5.0-build.4359+sha.f4bf744
  - 1.5.0-build.4358+sha.0d96995
  - 1.5.0-build.4357+sha.2a85a63
  - 1.5.0-build.4356+sha.00d2b2c
  - 1.5.0-build.4355+sha.865f606
  - 1.5.0-build.4354+sha.91c0b36
  - 1.5.0-build.4353+sha.c8768d1
  - 1.5.0-build.4352+sha.af6342d
  - 1.5.0-build.4351+sha.35eada6
  - 1.5.0-build.4350+sha.35eada6
  - 1.5.0-build.4349+sha.bfad2a4
  - 1.5.0-build.4348+sha.54e8165
  - 1.5.0-build.4347+sha.4fc7346
  - 1.5.0-build.4346+sha.b9bed7d
  - 1.5.0-build.4345+sha.b2fc39d
  - 1.5.0-build.4344+sha.8fe781f
  - 1.5.0-build.4343+sha.23932a2
  - 1.5.0-build.4342+sha.3ca4ca4
  - 1.5.0-build.4341+sha.3ca4ca4
  - 1.5.0-build.4340+sha.395f3ec
  - 1.5.0-build.4339+sha.53cb88a
  - 1.5.0-build.4338+sha.964a901
  - 1.5.0-build.4337+sha.a995ee1
  - 1.5.0-build.4336+sha.794d1c1
  - 1.5.0-build.4335+sha.662fb28
  - 1.5.0-build.4334+sha.ffb6b2f
  - 1.5.0-build.4333+sha.ffb6b2f
  - 1.5.0-build.4332+sha.941c1c3
  - 1.5.0-build.4331+sha.29a0598
  - 1.5.0-build.4330+sha.4038aab
  - 1.5.0-build.4329+sha.773efd0
  - 1.5.0-build.4328+sha.8088194
  - 1.5.0-build.4327+sha.2c8d87e
  - 1.5.0-build.4326+sha.33c67ce
  - 1.5.0-build.4325+sha.ad4296d
  - 1.5.0-build.4324+sha.469b14a
  - 1.5.0-build.4323+sha.1caf0b6
  - 1.5.0-build.4322+sha.9f716dd
  - 1.5.0-build.4321+sha.914a934
  - 1.5.0-build.4320+sha.a4ada8b
  - 1.5.0-build.4319+sha.40c974a
  - 1.5.0-build.4318+sha.8226ff8
  - 1.5.0-build.4317+sha.a8e03b3
  - 1.5.0-build.4316+sha.6f3e26c
  - 1.5.0-build.4315+sha.1c75ea6
  - 1.5.0-build.4314+sha.c8e1db2
  - 1.5.0-build.4313+sha.74ed286
  - 1.5.0-build.4312+sha.4ad0ca1
  - 1.5.0-build.4311+sha.beea571
  - 1.5.0-build.4310+sha.0c8a9a0
  - 1.5.0-build.4309+sha.fd83d37
  - 1.5.0-build.4308+sha.2fcfd75
  - 1.5.0-build.4307+sha.2d40507
  - 1.5.0-build.4306+sha.ecf9304
  - 1.5.0-build.4305+sha.b9ab887
  - 1.5.0-build.4304+sha.b9ab887
  - 1.5.0-build.4303+sha.00bf218
  - 1.5.0-build.4302+sha.95fbf16
  - 1.5.0-build.4301+sha.51a27c0
  - 1.5.0-build.4300+sha.f02811f
  - 1.5.0-build.4299+sha.bcf78eb
  - 1.5.0-build.4298+sha.3050dd1
  - 1.5.0-build.4297+sha.f047ad2
  - 1.5.0-build.4296+sha.049d3de
  - 1.5.0-build.4295+sha.00778aa
  - 1.5.0-build.4294+sha.6b123a0
  - 1.5.0-build.4291+sha.693021c
  - 1.5.0-build.4290+sha.693021c
  - 1.5.0-build.4289+sha.693021c
  - 1.5.0-build.4288+sha.dc818e1
  - 1.5.0-build.4287+sha.e51174b
  - 1.5.0-build.4286+sha.e51174b
  - 1.5.0-build.4285+sha.d077966
  - 1.5.0-build.4284+sha.0df4ff8
  - 1.5.0-build.4283+sha.6208b76
  - 1.5.0-build.4282+sha.70dac5a
  - 1.5.0-build.4281+sha.aafbd94
  - 1.5.0-build.4280+sha.e732f8e
  - 1.5.0-build.4279+sha.9f67da6
  - 1.5.0-build.4278+sha.b3a3c6a
  - 1.5.0-build.4277+sha.3af71be
  - 1.5.0-build.4274+sha.240d589
  - 1.5.0-build.4273+sha.8b27c3f
  - 1.5.0-build.4272+sha.8366622
  - 1.5.0-build.4271+sha.d3de006
  - 1.5.0-build.4270+sha.b7e5133
  - 1.5.0-build.4269+sha.b7e5133
  - 1.5.0-build.4268+sha.42c97c5
  - 1.5.0-build.4267+sha.e1f4f23
  - 1.5.0-build.4264+sha.630280c
  - 1.5.0-build.4263+sha.7dcfe5e
  - 1.5.0-build.4262+sha.9e83b83
  - 1.5.0-build.4261+sha.03726f7
  - 1.5.0-build.4260+sha.befeeb3
  - 1.5.0-build.4255+sha.652b83e
  - 1.5.0-build.4254+sha.20cf7d5
  - 1.5.0-build.4253+sha.ded2518
  - 1.5.0-build.4252+sha.b366f03
  - *plus over TWO THOUSAND more versions...*
```

New behavior:

```
$ bower info angular

{
  name: 'angular',
  version: '1.4.8',
  main: './angular.js',
  ignore: [],
  dependencies: {},
  homepage: 'https://github.com/angular/bower-angular'
}

Available versions:
  - 1.4.8
  - 1.4.7
  - 1.4.6
  - 1.4.5
  - 1.4.4
  - 1.4.3
  - 1.4.2
  - 1.4.1
  - 1.4.0
  - 1.3.20
  - 1.3.19
  - 1.3.18
  - 1.3.17
  - 1.3.16
  - 1.3.15
  - 1.3.14
  - 1.3.13
  - 1.3.12
  - 1.3.11
  - 1.3.10
  - 1.3.9
  - 1.3.8
  - 1.3.7
  - 1.3.6
  - 1.3.5
  - 1.3.4
  - 1.3.3
  - 1.3.2
  - 1.3.1
  - 1.3.0
  - 1.2.29
  - 1.2.28
  - 1.2.27
  - 1.2.26
  - 1.2.25
  - 1.2.24
  - 1.2.23
  - 1.2.22
  - 1.2.21
  - 1.2.20
  - 1.2.19
  - 1.2.18
  - 1.2.17
  - 1.2.16
  - 1.2.15
  - 1.2.14
  - 1.2.13
  - 1.2.12
  - 1.2.11
  - 1.2.10
  - 1.2.9
  - 1.2.8
  - 1.2.7
  - 1.2.6
  - 1.2.5
  - 1.2.4
  - 1.2.3
  - 1.2.2
  - 1.2.1
  - 1.2.0
  - 1.0.8
  - 1.0.7
  - 1.0.6
  - 1.0.5
  - 1.0.4
  - 1.0.3

Show 2867 additional prereleases with 'bower info angular --verbose'
You can request info for a specific version with 'bower info angular#<version>'
```