### PR TITLE
Fix name clashes in package extraction

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -9,6 +9,7 @@ var junk = require('junk');
 var createError = require('./createError');
 var createWriteStream = require('fs-write-stream-atomic');
 var destroy = require('destroy');
+var tmp = require('tmp');
 
 // This forces the default chunk size to something small in an attempt
 // to avoid issue #314
@@ -164,15 +165,11 @@ function isSingleDir(dir) {
     });
 }
 
-function moveSingleDirContents(dir) {
-    var destDir = path.dirname(dir);
-
-    return Q.nfcall(fs.readdir, dir)
-    .then(function (files) {
-        var promises;
-
-        promises = files.map(function (file) {
-            var src = path.join(dir, file);
+function moveDirectory(srcDir, destDir) {
+    return Q.nfcall(fs.readdir, srcDir)
+    .then(function(files) {
+        var promises = files.map(function (file) {
+            var src = path.join(srcDir, file);
             var dst = path.join(destDir, file);
 
             return Q.nfcall(fs.rename, src, dst);
@@ -181,7 +178,7 @@ function moveSingleDirContents(dir) {
         return Q.all(promises);
     })
     .then(function () {
-        return Q.nfcall(fs.rmdir, dir);
+        return Q.nfcall(fs.rmdir, srcDir);
     });
 }
 
@@ -215,44 +212,53 @@ function extract(src, dst, opts) {
         return Q.reject(createError('File ' + src + ' is not a known archive', 'ENOTARCHIVE'));
     }
 
-    // Check archive file size
-    promise = Q.nfcall(fs.stat, src)
-    .then(function (stat) {
-        if (stat.size <= 8) {
-            throw createError('File ' + src + ' is an invalid archive', 'ENOTARCHIVE');
+    // Extract to a temporary directory in case of file name clashes
+    return Q.nfcall(tmp.dir, {
+        template: dst + '-XXXXXX',
+        mode: 0777 & ~process.umask()
+    }).then(function (tempDir) {
+        // nfcall may return multiple callback arguments as an array
+        return Array.isArray(tempDir) ? tempDir[0] : tempDir;
+    }).then(function (tempDir) {
+
+        // Check archive file size
+        promise = Q.nfcall(fs.stat, src)
+        .then(function (stat) {
+            if (stat.size <= 8) {
+                throw createError('File ' + src + ' is an invalid archive', 'ENOTARCHIVE');
+            }
+
+            // Extract archive
+            return extractor(src, tempDir);
+        });
+
+        // Remove archive
+        if (!opts.keepArchive) {
+            promise = promise
+            .then(function () {
+                return Q.nfcall(fs.unlink, src);
+            });
         }
 
-        // Extract archive
-        return extractor(src, dst);
-    });
-
-    // TODO: There's an issue here if the src and dst are the same and
-    //       The zip name is the same as some of the zip file contents
-    //       Maybe create a temp directory inside dst, unzip it there,
-    //       unlink zip and then move contents
-
-    // Remove archive
-    if (!opts.keepArchive) {
+        // Move contents from the temporary directory
+        // If the contents are a single directory (and we're not preserving structure),
+        // move its contents directly instead.
         promise = promise
         .then(function () {
-            return Q.nfcall(fs.unlink, src);
-        });
-    }
-
-    // Move contents if a single directory was extracted
-    if (!opts.keepStructure) {
-        promise = promise
-        .then(function () {
-            return isSingleDir(dst);
+            return isSingleDir(tempDir);
         })
         .then(function (singleDir) {
-            return singleDir ? moveSingleDirContents(singleDir) : null;
+            if (singleDir && !opts.keepStructure) {
+                return moveDirectory(singleDir, dst);
+            } else {
+                return moveDirectory(tempDir, dst);
+            }
         });
-    }
 
-    // Resolve promise to the dst dir
-    return promise.then(function () {
-        return dst;
+        // Resolve promise to the dst dir
+        return promise.then(function () {
+            return dst;
+        });
     });
 }
 

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -462,7 +462,7 @@ describe('bower install', function() {
 
         // Create an archive containing the main package
         var archiveDeferred = Q.defer();
-        var archivePath = path.join(parentDir, mainPackageBaseName + ".tar")
+        var archivePath = path.join(parentDir, mainPackageBaseName + '.tar');
         var stream = tar.pack(parentDir, { entries: [mainPackageBaseName] });
         stream
             .pipe(fs.createWriteStream(archivePath))
@@ -483,7 +483,7 @@ describe('bower install', function() {
             return helpers.run(install, [[archivePath]]);
         })
         .then(function() {
-            expect(tempDir.read(path.join('bower_components', 'package', mainPackageBaseName, "test.js"))).to.contain('test');
+            expect(tempDir.read(path.join('bower_components', 'package', mainPackageBaseName, 'test.js'))).to.contain('test');
         });
     });
 
@@ -495,7 +495,7 @@ describe('bower install', function() {
         });
 
         var archiveDeferred = Q.defer();
-        var archivePath = path.join(parentDir, "package.tar")
+        var archivePath = path.join(parentDir, 'package.tar');
         var stream = tar.pack(mainPackage.path);
         stream
             .pipe(fs.createWriteStream(archivePath))
@@ -516,7 +516,7 @@ describe('bower install', function() {
             return helpers.run(install, [[archivePath]]);
         })
         .then(function() {
-            expect(tempDir.read(path.join('bower_components', 'package', "package.tar"))).to.contain('test');
+            expect(tempDir.read(path.join('bower_components', 'package', 'package.tar'))).to.contain('test');
         });
     });
 });


### PR DESCRIPTION
Prevent extraction failing if a package archive contains a file with the same name as the archive, or a single directory with a subdirectory with the same name.

The former was picked up from a TODO in the codebase, the latter from #1935.