### PR TITLE
Cache data for already traversed packages

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -252,13 +252,22 @@ Manager.prototype.install = function (json) {
     }.bind(this));
 };
 
-Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps) {
+Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps, accumulatedDataByName) {
     var names;
     var extra;
 
     var data = {};
 
     upperDeps = upperDeps || [];
+    var decEndpointCacheKey = decEndpoint.name + decEndpoint.target;
+
+    accumulatedDataByName = accumulatedDataByName || {};
+    if (accumulatedDataByName[decEndpointCacheKey]) {
+        return accumulatedDataByName[decEndpointCacheKey];
+    }
+
+    accumulatedDataByName[decEndpointCacheKey] = data;
+
     data.endpoint = mout.object.pick(decEndpoint, ['name', 'source', 'target']);
 
     if (decEndpoint.canonicalDir) {
@@ -287,7 +296,8 @@ Manager.prototype.toData = function (decEndpoint, extraKeys, upperDeps) {
             if (!mout.array.contains(upperDeps, name)) {
                 data.dependencies[name] = this.toData(decEndpoint.dependencies[name],
                     extraKeys,
-                    upperDeps.concat(decEndpoint.name));
+                    upperDeps.concat(decEndpoint.name),
+                    accumulatedDataByName);
             }
         }, this);
     }

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -316,6 +316,208 @@ describe('bower install', function() {
         });
     });
 
+    describe('doubly referenced packages', function () {
+        it('installs doubly referenced dependencies', function () {
+            var package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2'
+                }
+            }).prepare();
+
+            var package3 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package3',
+                    dependencies: {
+                        package2: package2.path
+                    }
+                }
+            }).prepare();
+
+            tempDir.prepare({
+                'bower.json': {
+                    name: 'package',
+                    dependencies: {
+                        package2: package2.path,
+                        package3: package3.path
+                    }
+                }
+            });
+
+            return helpers.run(install).then(function() {
+                expect(tempDir.exists('bower_components/package2')).to.equal(true);
+                expect(tempDir.exists('bower_components/package3')).to.equal(true);
+            });
+        });
+
+        it('installs doubly referenced dependencies, directly depending on different versions', function () {
+            var package3 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package3'
+                }
+            }).prepare();
+
+            gitPackage.prepareGit({
+                '1.0.0': {
+                    'bower.json': {
+                        name: 'gitPackage',
+                        dependencies: {
+                            package3: package3.path
+                        }
+                    },
+                    'version.txt': '1.0.0'
+                },
+                '1.0.1': {
+                    'bower.json': {
+                        name: 'package'
+                    },
+                    'version.txt': '1.0.1'
+                }
+            });
+
+            var package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2',
+                    dependencies: {
+                        gitPackage: gitPackage.path + '#1.0.1'
+                    }
+                }
+            }).prepare();
+
+
+            tempDir.prepare({
+                'bower.json': {
+                    name: 'package',
+                    dependencies: {
+                        gitPackage: gitPackage.path + '#^1.0.0',
+                        package2: package2.path
+                    }
+                }
+            });
+
+            return helpers.run(install).then(function() {
+                expect(tempDir.exists('bower_components/package2')).to.equal(true);
+                expect(tempDir.exists('bower_components/package3')).to.equal(false);
+                expect(tempDir.exists('bower_components/gitPackage')).to.equal(true);
+                expect(tempDir.read('bower_components/gitPackage/version.txt')).to.contain('1.0.1');
+            });
+        });
+
+        it('installs doubly referenced dependencies, indirectly depending on different versions', function () {
+            var package4 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package4'
+                }
+            }).prepare();
+
+            gitPackage.prepareGit({
+                '1.0.0': {
+                    'bower.json': {
+                        name: 'gitPackage',
+                        dependencies: {
+                            package4: package4.path
+                        }
+                    },
+                    'version.txt': '1.0.0'
+                },
+                '1.0.1': {
+                    'bower.json': {
+                        name: 'package'
+                    },
+                    'version.txt': '1.0.1'
+                }
+            });
+
+            var package3 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package3',
+                    dependencies: {
+                        gitPackage: gitPackage.path + '#1.0.1'
+                    }
+                }
+            }).prepare();
+
+            var package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2',
+                    dependencies: {
+                        gitPackage: gitPackage.path + '#^1.0.0',
+                        package3: package3.path
+                    }
+                }
+            }).prepare();
+
+            tempDir.prepare({
+                'bower.json': {
+                    name: 'package',
+                    dependencies: {
+                        package2: package2.path
+                    }
+                }
+            });
+
+            return helpers.run(install).then(function() {
+                // Package4 is only a dependency of gitPackage#1.0.0.
+                // This one should not have been resolved.
+                // Therefore, this package should not have been created
+                expect(tempDir.exists('bower_components/package4')).to.equal(false);
+                expect(tempDir.exists('bower_components/package2')).to.equal(true);
+                expect(tempDir.exists('bower_components/package3')).to.equal(true);
+                expect(tempDir.exists('bower_components/gitPackage')).to.equal(true);
+                expect(tempDir.read('bower_components/gitPackage/version.txt')).to.contain('1.0.1');
+            });
+        });
+
+        it('fails installing doubly referenced dependencies, indirectly depending on conflicting versions', function (done) {
+            gitPackage.prepareGit({
+                '1.0.0': {
+                    'bower.json': {
+                        name: 'gitPackage'
+                    },
+                    'version.txt': '1.0.0'
+                },
+                '1.0.1': {
+                    'bower.json': {
+                        name: 'gitPackage'
+                    },
+                    'version.txt': '1.0.1'
+                }
+            });
+
+            var package3 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package3',
+                    dependencies: {
+                        gitPackage: gitPackage.path + '#1.0.0'
+                    }
+                }
+            }).prepare();
+
+            var package2 = new helpers.TempDir({
+                'bower.json': {
+                    name: 'package2',
+                    dependencies: {
+                        gitPackage: gitPackage.path + '#1.0.1',
+                        package3: package3.path
+                    }
+                }
+            }).prepare();
+
+            tempDir.prepare({
+                'bower.json': {
+                    name: 'package',
+                    dependencies: {
+                        package2: package2.path
+                    }
+                }
+            });
+
+            return helpers.run(install).fail(function (error) {
+                expect(error.code).to.contain('ECONFLICT');
+                done();
+            });
+        });
+    });
+
     it('works for dependencies that point to tar files', function() {
         var packageDir = path.join(__dirname, '../assets/package-tar.tar');
         tempDir.prepare({

--- a/test/core/Manager.js
+++ b/test/core/Manager.js
@@ -198,6 +198,106 @@ describe('Manager', function () {
         });
     });
 
+    describe('toData', function () {
+
+        it('summarizes dependencies', function () {
+            var data = manager.toData({
+                name: 'foo',
+                source: 'google.com',
+                target: '*',
+                dependencies: {
+                    bar: {
+                        name: 'bar',
+                        source: 'facebook.com',
+                        target: '*'
+                    }
+                }
+            });
+            expect(data).to.eql({
+                dependencies: {
+                    bar: {
+                        endpoint: {
+                            name: 'bar',
+                            source: 'facebook.com',
+                            target: '*'
+                        },
+                        nrDependants: 0
+                    }
+                },
+                endpoint: {
+                    name: 'foo',
+                    source: 'google.com',
+                    target: '*'
+                },
+                nrDependants: 0
+            });
+        });
+
+        it('summarizes dependencies on different versions of a same package', function () {
+            var data = manager.toData({
+                name: 'foo',
+                source: 'google.com',
+                target: '*',
+                dependencies: {
+                    bar: {
+                        name: 'bar',
+                        source: 'facebook.com',
+                        target: '*',
+                        dependencies: {
+                            baz: {
+                                name: 'baz',
+                                source: 'yahoo.com',
+                                target: 'something'
+                            }
+                        }
+                    },
+                    baz: {
+                        name: 'baz',
+                        source: 'yahoo.com',
+                        target: 'something else'
+                    }
+                }
+            });
+
+            expect(data).to.eql({
+                dependencies: {
+                    bar: {
+                        endpoint: {
+                            name: 'bar',
+                            source: 'facebook.com',
+                            target: '*'
+                        },
+                        dependencies: {
+                            baz: {
+                                endpoint: {
+                                    name: 'baz',
+                                    source: 'yahoo.com',
+                                    target: 'something'
+                                },
+                                nrDependants: 0
+                            }
+                        },
+                        nrDependants: 0
+                    },
+                    baz: {
+                        endpoint: {
+                            name: 'baz',
+                            source: 'yahoo.com',
+                            target: 'something else'
+                        },
+                        nrDependants: 0
+                    }
+                },
+                endpoint: {
+                    name: 'foo',
+                    source: 'google.com',
+                    target: '*'
+                },
+                nrDependants: 0
+            });
+        });
+    });
+
     describe('_uniquify', function () {
 
         it('leaves last unique element', function () {


### PR DESCRIPTION
This improves the performance of bower install by making the amount of data being traversed proportional to the amount of unique packages installed, instead of all nodes in the dependency tree.

We at FontoXML use bower as our dependency manager. Because we use a very modular architecture (150+ packages, with loads of inter-dependencies), we ran into consistent out of memory issues in Bower.

We have narrowed it down to the Manager#toData function, which is run twice. This function recurses to summarize the dependencies of installed packages. It does not hold duplicate dependencies into account.

Because dependencies should be unique by name (the upperDeps check uses this), we should not have to recurse for packages we have already seen in this full outer call of Manager#toData.
