### PR TITLE
Added the --force docs to the --help command

### DIFF
--- a/templates/json/help-install.json
+++ b/templates/json/help-install.json
@@ -12,6 +12,11 @@
             "description": "Force latest version on conflict"
         },
         {
+            "shorthand":   "-f",
+            "flag":        "--force",
+            "description": "If dependencies are installed, it reinstalls all installed components. It also forces installation even when there are non-bower directories with the same name in the components directory. Also bypasses the cache and overwrites to the cache anyway."
+        },
+        {
             "shorthand":   "-h",
             "flag":        "--help",
             "description": "Show this help message"

--- a/templates/json/help-register.json
+++ b/templates/json/help-register.json
@@ -6,6 +6,11 @@
     ],
     "options": [
         {
+            "shorthand":   "-f",
+            "flag":        "--force",
+            "description": "Bypasses confirmation. Bower login is still needed."
+        },
+        {
             "shorthand":   "-h",
             "flag":        "--help",
             "description": "Show this help message"

--- a/templates/json/help-uninstall.json
+++ b/templates/json/help-uninstall.json
@@ -6,6 +6,11 @@
     ],
     "options": [
         {
+            "shorthand":   "-f",
+            "flag":        "--force",
+            "description": "Continues uninstallation even after a dependency conflict"
+        },
+        {
             "shorthand":   "-h",
             "flag":        "--help",
             "description": "Show this help message"

--- a/templates/json/help-unregister.json
+++ b/templates/json/help-unregister.json
@@ -6,6 +6,11 @@
     ],
     "options": [
         {
+            "shorthand":   "-f",
+            "flag":        "--force",
+            "description": "Bypasses confirmation. Bower login is still needed."
+        },
+        {
             "shorthand":   "-h",
             "flag":        "--help",
             "description": "Show this help message"


### PR DESCRIPTION
The `bower help` command will now display information on the `--force` option where it applies. This is for `install` `uninstall` `register` and `unregister`.

This was requested as per @sheerun on bower/bower.github.io#203