### PR TITLE
Ignore bower.json "version" field in `bower version`

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -29,7 +29,7 @@ function bump(project, versionArg, message) {
         }
     })
     .then(project.getJson.bind(project))
-    .then(function(/*json (ignored)*/) {
+    .then(function (/*json (ignored)*/) {
         return currentGitVersion(cwd);
     })
     .then(function (currentVersion) {
@@ -110,7 +110,7 @@ function gitCommitAndTag(cwd, newVersion, message) {
 
 function currentGitVersion(cwd) {
     return Q.nfcall(execFile, 'git', ['tag'], {env: process.env, cwd: cwd})
-        .then(function(res) {
+        .then(function (res) {
             var versions = res[0]
                 .split(/\r?\n/)
                 .map(stripV)

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -21,22 +21,20 @@ function version(logger, versionArg, options, config) {
 function bump(project, versionArg, message) {
     var cwd = project._config.cwd || process.cwd();
     var newVersion;
-    var doGitCommit = false;
 
     return checkGit(cwd)
     .then(function (hasGit) {
-        doGitCommit = hasGit;
+        if (!hasGit) {
+            throw createError('This directory does not appear to be a git repository', 'ENOTGITREPOSITORY');
+        }
     })
     .then(project.getJson.bind(project))
-    .then(function (json) {
-        newVersion = getNewVersion(json.version, versionArg);
-        json.version = newVersion;
+    .then(function(/*json (ignored)*/) {
+        return currentGitVersion(cwd);
     })
-    .then(project.saveJson.bind(project))
-    .then(function () {
-        if (doGitCommit) {
-            return gitCommitAndTag(cwd, newVersion, message);
-        }
+    .then(function (currentVersion) {
+        newVersion = getNewVersion(currentVersion, versionArg);
+        return gitCommitAndTag(cwd, newVersion, message);
     })
     .then(function () {
         console.log('v' + newVersion);
@@ -104,13 +102,31 @@ function gitCommitAndTag(cwd, newVersion, message) {
     var tag = 'v' + newVersion;
     message = message || tag;
     message = message.replace(/%s/g, newVersion);
-    return Q.nfcall(execFile, 'git', ['add', 'bower.json'], {env: process.env, cwd: cwd})
+    return Q.nfcall(execFile, 'git', ['commit', '-m', message, '--allow-empty'], {env: process.env, cwd: cwd})
     .then(function () {
-        return Q.nfcall(execFile, 'git', ['commit', '-m', message], {env: process.env, cwd: cwd});
-    })
-    .then(function () {
-        return Q.nfcall(execFile, 'git', ['tag', tag, '-am', message], {env: process.env, cwd: cwd});
+        Q.nfcall(execFile, 'git', ['tag', tag, '-am', message], {env: process.env, cwd: cwd});
     });
+}
+
+function currentGitVersion(cwd) {
+    return Q.nfcall(execFile, 'git', ['tag'], {env: process.env, cwd: cwd})
+        .then(function(res) {
+            var versions = res[0]
+                .split(/\r?\n/)
+                .map(stripV)
+                .filter(semver.valid)
+                .sort(semver.compare);
+
+            return versions[versions.length - 1] || '0.0.0';
+        });
+}
+
+function stripV(s) {
+    if (s[0] === 'v') {
+        return s.slice(1);
+    } else {
+        return s;
+    }
 }
 
 // -------------------

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -109,7 +109,7 @@ function gitCommitAndTag(cwd, newVersion, message) {
 }
 
 function currentGitVersion(cwd) {
-    return Q.nfcall(execFile, 'git', ['tag'], {env: process.env, cwd: cwd})
+    return Q.nfcall(execFile, 'git', ['describe', '--abbrev=0', '--tags'], {env: process.env, cwd: cwd})
         .then(function (res) {
             var versions = res[0]
                 .split(/\r?\n/)
@@ -118,6 +118,8 @@ function currentGitVersion(cwd) {
                 .sort(semver.compare);
 
             return versions[versions.length - 1] || '0.0.0';
+        }, function () {
+            return '0.0.0';
         });
 }
 

--- a/test/commands/version.js
+++ b/test/commands/version.js
@@ -16,39 +16,39 @@ describe('bower version', function () {
     var packageWithoutTags = new helpers.TempDir({});
 
 
-    it('bumps patch version', function() {
+    it('bumps patch version', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function() {
+        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function () {
             expect(mainPackage.latestGitTag()).to.be('0.0.1');
         });
     });
 
-    it('bumps minor version', function() {
+    it('bumps minor version', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['minor', {}, { cwd: mainPackage.path }]).then(function() {
+        return helpers.run(version, ['minor', {}, { cwd: mainPackage.path }]).then(function () {
             expect(mainPackage.latestGitTag()).to.be('0.1.0');
         });
     });
 
-    it('bumps major version', function() {
+    it('bumps major version', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['major', {}, { cwd: mainPackage.path }]).then(function() {
+        return helpers.run(version, ['major', {}, { cwd: mainPackage.path }]).then(function () {
             expect(mainPackage.latestGitTag()).to.be('1.0.0');
         });
     });
 
-    it('changes version', function() {
+    it('changes version', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['1.2.3', {}, { cwd: mainPackage.path }]).then(function() {
+        return helpers.run(version, ['1.2.3', {}, { cwd: mainPackage.path }]).then(function () {
             expect(mainPackage.latestGitTag()).to.be('1.2.3');
         });
     });
 
-    it('returns the new version', function() {
+    it('returns the new version', function () {
         mainPackage.prepareGit();
 
         return helpers.run(version, ['major', {}, { cwd: mainPackage.path }]).then(function (results) {
@@ -56,40 +56,40 @@ describe('bower version', function () {
         });
     });
 
-    it('fails on a dirty git repository', function() {
+    it('fails on a dirty git repository', function () {
         mainPackage.prepareGit();
         mainPackage.create({
             'dirty.txt': 'This file has not been committed'
         });
 
-        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(null, function(err) {
+        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(null, function (err) {
             expect(err).to.be.an(Error);
             expect(err.code).to.be('ENOTGITREPOSITORY');
         });
     });
 
-    it('fails when the version is not changed', function() {
+    it('fails when the version is not changed', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['0.0.0', {}, { cwd: mainPackage.path }]).then(null, function(err) {
+        return helpers.run(version, ['0.0.0', {}, { cwd: mainPackage.path }]).then(null, function (err) {
             expect(err).to.be.an(Error);
             expect(err.code).to.be('EVERSIONNOTCHANGED');
         });
     });
 
-    it('fails with an invalid argument', function() {
+    it('fails with an invalid argument', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['lol', {}, { cwd: mainPackage.path }]).then(null, function(err) {
+        return helpers.run(version, ['lol', {}, { cwd: mainPackage.path }]).then(null, function (err) {
             expect(err).to.be.an(Error);
             expect(err.code).to.be('EINVALIDVERSION');
         });
     });
 
-    it('bumps with custom commit message', function() {
+    it('bumps with custom commit message', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['patch', { message: 'Bumping %s, because what'}, { cwd: mainPackage.path }]).then(function() {
+        return helpers.run(version, ['patch', { message: 'Bumping %s, because what'}, { cwd: mainPackage.path }]).then(function () {
             var tags = mainPackage.git('tag');
             expect(tags).to.be('v0.0.0\nv0.0.1\n');
             var message = mainPackage.git('log', '--pretty=format:%s', '-n1');
@@ -97,10 +97,10 @@ describe('bower version', function () {
         });
     });
 
-    it('creates commit and tags', function() {
+    it('creates commit and tags', function () {
         mainPackage.prepareGit();
 
-        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function() {
+        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function () {
             var tags = mainPackage.git('tag');
             expect(tags).to.be('v0.0.0\nv0.0.1\n');
             var message = mainPackage.git('log', '--pretty=format:%s', '-n1');
@@ -108,7 +108,7 @@ describe('bower version', function () {
         });
     });
 
-    it('assumes v0.0.0 when no tags exist', function() {
+    it('assumes v0.0.0 when no tags exist', function () {
         packageWithoutTags.prepareGit();
         packageWithoutTags.create({
             'index.js': 'console.log("hello, world");'
@@ -116,7 +116,7 @@ describe('bower version', function () {
         packageWithoutTags.git('add', '-A');
         packageWithoutTags.git('commit', '-m"commit"');
 
-        return helpers.run(version, ['major', {}, { cwd: packageWithoutTags.path }]).then(function() {
+        return helpers.run(version, ['major', {}, { cwd: packageWithoutTags.path }]).then(function () {
             expect(packageWithoutTags.latestGitTag()).to.be('1.0.0');
         });
     });

--- a/test/commands/version.js
+++ b/test/commands/version.js
@@ -3,87 +3,121 @@ var expect = require('expect.js');
 var helpers = require('../helpers');
 var version = helpers.require('lib/commands').version;
 
-describe('bower list', function () {
+describe('bower version', function () {
 
     var mainPackage = new helpers.TempDir({
-        'bower.json': {
-            name: 'foobar',
-            version: '0.0.0'
-        }
-    });
-
-    var gitPackage = new helpers.TempDir({
         'v0.0.0': {
             'bower.json': {
                 name: 'foobar',
-                version: '0.0.0'
             }
         }
     });
 
-    it('bumps patch version', function () {
-        mainPackage.prepare();
+    var packageWithoutTags = new helpers.TempDir({});
 
-        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function () {
-            expect(mainPackage.readJson('bower.json').version).to.be('0.0.1');
+
+    it('bumps patch version', function() {
+        mainPackage.prepareGit();
+
+        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function() {
+            expect(mainPackage.latestGitTag()).to.be('0.0.1');
         });
     });
 
-    it('bumps minor version', function () {
-        mainPackage.prepare();
+    it('bumps minor version', function() {
+        mainPackage.prepareGit();
 
-        return helpers.run(version, ['minor', {}, { cwd: mainPackage.path }]).then(function () {
-            expect(mainPackage.readJson('bower.json').version).to.be('0.1.0');
+        return helpers.run(version, ['minor', {}, { cwd: mainPackage.path }]).then(function() {
+            expect(mainPackage.latestGitTag()).to.be('0.1.0');
         });
     });
 
-    it('bumps major version', function () {
-        mainPackage.prepare();
+    it('bumps major version', function() {
+        mainPackage.prepareGit();
 
-        return helpers.run(version, ['major', {}, { cwd: mainPackage.path }]).then(function () {
-            expect(mainPackage.readJson('bower.json').version).to.be('1.0.0');
+        return helpers.run(version, ['major', {}, { cwd: mainPackage.path }]).then(function() {
+            expect(mainPackage.latestGitTag()).to.be('1.0.0');
         });
     });
 
-    it('changes version', function () {
-        mainPackage.prepare();
+    it('changes version', function() {
+        mainPackage.prepareGit();
 
-        return helpers.run(version, ['1.2.3', {}, { cwd: mainPackage.path }]).then(function () {
-            expect(mainPackage.readJson('bower.json').version).to.be('1.2.3');
+        return helpers.run(version, ['1.2.3', {}, { cwd: mainPackage.path }]).then(function() {
+            expect(mainPackage.latestGitTag()).to.be('1.2.3');
         });
     });
 
-    it('returns the new version', function () {
-        mainPackage.prepare();
+    it('returns the new version', function() {
+        mainPackage.prepareGit();
 
         return helpers.run(version, ['major', {}, { cwd: mainPackage.path }]).then(function (results) {
             expect(results[0]).to.be('1.0.0');
         });
     });
 
-    it('bumps patch version, create commit, and tag', function () {
-        gitPackage.prepareGit();
+    it('fails on a dirty git repository', function() {
+        mainPackage.prepareGit();
+        mainPackage.create({
+            'dirty.txt': 'This file has not been committed'
+        });
 
-        return helpers.run(version, ['patch', {}, { cwd: gitPackage.path }]).then(function () {
-            expect(gitPackage.readJson('bower.json').version).to.be('0.0.1');
+        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(null, function(err) {
+            expect(err).to.be.an(Error);
+            expect(err.code).to.be('ENOTGITREPOSITORY');
+        });
+    });
 
-            var tags = gitPackage.git('tag');
+    it('fails when the version is not changed', function() {
+        mainPackage.prepareGit();
+
+        return helpers.run(version, ['0.0.0', {}, { cwd: mainPackage.path }]).then(null, function(err) {
+            expect(err).to.be.an(Error);
+            expect(err.code).to.be('EVERSIONNOTCHANGED');
+        });
+    });
+
+    it('fails with an invalid argument', function() {
+        mainPackage.prepareGit();
+
+        return helpers.run(version, ['lol', {}, { cwd: mainPackage.path }]).then(null, function(err) {
+            expect(err).to.be.an(Error);
+            expect(err.code).to.be('EINVALIDVERSION');
+        });
+    });
+
+    it('bumps with custom commit message', function() {
+        mainPackage.prepareGit();
+
+        return helpers.run(version, ['patch', { message: 'Bumping %s, because what'}, { cwd: mainPackage.path }]).then(function() {
+            var tags = mainPackage.git('tag');
             expect(tags).to.be('v0.0.0\nv0.0.1\n');
-            var message = gitPackage.git('log', '--pretty=format:%s', '-n1');
+            var message = mainPackage.git('log', '--pretty=format:%s', '-n1');
+            expect(message).to.be('Bumping 0.0.1, because what');
+        });
+    });
+
+    it('creates commit and tags', function() {
+        mainPackage.prepareGit();
+
+        return helpers.run(version, ['patch', {}, { cwd: mainPackage.path }]).then(function() {
+            var tags = mainPackage.git('tag');
+            expect(tags).to.be('v0.0.0\nv0.0.1\n');
+            var message = mainPackage.git('log', '--pretty=format:%s', '-n1');
             expect(message).to.be('v0.0.1');
         });
     });
 
-    it('bumps with custom commit message', function () {
-        gitPackage.prepareGit();
+    it('assumes v0.0.0 when no tags exist', function() {
+        packageWithoutTags.prepareGit();
+        packageWithoutTags.create({
+            'index.js': 'console.log("hello, world");'
+        });
+        packageWithoutTags.git('add', '-A');
+        packageWithoutTags.git('commit', '-m"commit"');
 
-        return helpers.run(version, ['patch', { message: 'Bumping %s, because what'}, { cwd: gitPackage.path }]).then(function () {
-            expect(gitPackage.readJson('bower.json').version).to.be('0.0.1');
-
-            var tags = gitPackage.git('tag');
-            expect(tags).to.be('v0.0.0\nv0.0.1\n');
-            var message = gitPackage.git('log', '--pretty=format:%s', '-n1');
-            expect(message).to.be('Bumping 0.0.1, because what');
+        return helpers.run(version, ['major', {}, { cwd: packageWithoutTags.path }]).then(function() {
+            expect(packageWithoutTags.latestGitTag()).to.be('1.0.0');
         });
     });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -159,7 +159,7 @@ exports.TempDir = (function () {
     TempDir.prototype.latestGitTag = function () {
         var versions = this.git('tag')
             .split(/\r?\n/)
-            .map(function(t) { return t.slice(1); })
+            .map(function (t) { return t.slice(1); })
             .filter(semver.valid)
             .sort(semver.compare);
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,6 +14,7 @@ var proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 var spawnSync = require('spawn-sync');
 var config = require('../lib/config');
 var nock = require('nock');
+var semver = require('semver');
 
 // For better promise errors
 Q.longStackSupport = true;
@@ -152,6 +153,20 @@ exports.TempDir = (function () {
             throw new Error(result.stderr);
         } else {
             return result.stdout.toString();
+        }
+    };
+
+    TempDir.prototype.latestGitTag = function () {
+        var versions = this.git('tag')
+            .split(/\r?\n/)
+            .map(function(t) { return t.slice(1); })
+            .filter(semver.valid)
+            .sort(semver.compare);
+
+        if (versions.length >= 1) {
+            return versions[versions.length - 1];
+        } else {
+            throw new Error('No valid git version tags found.');
         }
     };
 


### PR DESCRIPTION
Fixes #2139. See the commits for a description of the changes. I just went ahead and did this, because it was easy.

I was thinking that it might be a good idea to warn if the "version" field exists, too. If you agree, where should that go?

Also, if bower now uses tags for versions, I suppose we should support svn too?