### PR TITLE
Use caret on install save

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -386,7 +386,7 @@ Manager.prototype._onFetchSuccess = function (decEndpoint, canonicalDir, pkgMeta
 
     // If the package is not targetable, flag it
     // It will be needed later so that untargetable endpoints
-    // will not get * converted to ~version
+    // will not get * converted to ^version
     if (!isTargetable) {
         decEndpoint.untargetable = true;
     }
@@ -595,7 +595,7 @@ Manager.prototype._dissect = function () {
         // If they are not, the resolver is incapable of handling targets
         semvers.forEach(function (decEndpoint) {
             if (decEndpoint.newly && decEndpoint.target === '*' && !decEndpoint.untargetable) {
-                decEndpoint.target = '~' + decEndpoint.pkgMeta.version;
+                decEndpoint.target = '^' + decEndpoint.pkgMeta.version;
                 decEndpoint.originalTarget = '*';
             }
         });


### PR DESCRIPTION
This fix brings us inline with how npm installs work and also brings us
more inline with how semver is supposed to be used.

Fixes #2144