### PR TITLE
add support for save and save-exact in .bowerrc

### DIFF
--- a/lib/core/Project.js
+++ b/lib/core/Project.js
@@ -82,14 +82,14 @@ Project.prototype.install = function (decEndpoints, options, config) {
     })
     .then(function (installed) {
         // Handle save and saveDev options
-        if (that._options.save || that._options.saveDev || that._options.saveExact) {
+        if (that._options.save || that._options.saveDev || that._options.saveExact || that._config.save || that._config.saveExact) {
             // Cycle through the specified endpoints
             decEndpoints.forEach(function (decEndpoint) {
                 var jsonEndpoint;
 
                 jsonEndpoint = endpointParser.decomposed2json(decEndpoint);
 
-                if (that._options.saveExact) {
+                if (that._options.saveExact || that._config.saveExact) {
                     if (decEndpoint.name !== decEndpoint.source) {
                         jsonEndpoint[decEndpoint.name] = decEndpoint.source + '#' + decEndpoint.pkgMeta.version;
                     } else {
@@ -741,7 +741,7 @@ Project.prototype._removePackages = function (packages) {
             }
 
             // Remove from json only if successfully deleted
-            if (that._options.save && that._json.dependencies) {
+            if ((that._options.save || that._config.save) && that._json.dependencies) {
                 promise = promise
                 .then(function () {
                     delete that._json.dependencies[name];

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -85,6 +85,24 @@ describe('bower install', function() {
         });
     });
 
+    it('writes to bower.json if save config setting is set to true', function() {
+        mainPackage.prepare();
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test'
+            }
+        });
+
+        return helpers.run(install, [
+            [mainPackage.path], {}, {
+                save: true
+            }
+        ]).then(function() {
+            expect(tempDir.read('bower.json')).to.contain('dependencies');
+        });
+    });
+
     it('writes an exact version number to dependencies in bower.json if --save --save-exact flags are used', function() {
         mainPackage.prepare({
             'bower.json': {
@@ -101,6 +119,30 @@ describe('bower install', function() {
 
         return helpers.run(install, [
             [mainPackage.path], {
+                saveExact: true,
+                save: true
+            }
+        ]).then(function() {
+            expect(tempDir.readJson('bower.json').dependencies.package).to.equal(mainPackage.path + '#1.2.3');
+        });
+    });
+
+    it('writes an exact version number to dependencies in bower.json if save and save-exact config settings are set to true', function() {
+        mainPackage.prepare({
+            'bower.json': {
+                name: 'package',
+                version: '1.2.3'
+            }
+        });
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test'
+            }
+        });
+
+        return helpers.run(install, [
+            [mainPackage.path], {}, {
                 saveExact: true,
                 save: true
             }
@@ -127,6 +169,31 @@ describe('bower install', function() {
             [mainPackage.path], {
                 saveExact: true,
                 saveDev: true
+            }
+        ]).then(function() {
+            expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(mainPackage.path + '#0.1.0');
+        });
+    });
+
+    it('writes an exact version number to devDependencies in bower.json if save-exact config setting is true and --save-dev flag is used', function() {
+        mainPackage.prepare({
+            'bower.json': {
+                name: 'package',
+                version: '0.1.0'
+            }
+        });
+
+        tempDir.prepare({
+            'bower.json': {
+                name: 'test'
+            }
+        });
+
+        return helpers.run(install, [
+            [mainPackage.path], {
+                saveDev: true
+            }, {
+                saveExact: true
             }
         ]).then(function() {
             expect(tempDir.readJson('bower.json').devDependencies.package).to.equal(mainPackage.path + '#0.1.0');

--- a/test/commands/uninstall.js
+++ b/test/commands/uninstall.js
@@ -54,6 +54,17 @@ describe('bower uninstall', function () {
         });
     });
 
+    it('removes dependency from bower.json if save config setting is true', function () {
+        var configWithSave = {
+            cwd: tempDir.path,
+            interactive: true,
+            save: true
+        };
+        return helpers.run(uninstall, [['underscore'], {}, configWithSave]).then(function () {
+            expect(bowerJson().dependencies).to.eql({});
+        });
+    });
+
     it('removes dependency from relative config.directory', function () {
         var targetPath = path.resolve(tempDir.path, 'other_directory/underscore');
         mkdirp.sync(targetPath);


### PR DESCRIPTION
Hi all, 

I'm a long-time fan and user or bower, first-time PRer. I am grateful to bower's maintainers, and I'd be glad for any feedback or suggestions.

This PR is in response to issue #1040, specifically comments from @svengt and @sheerun. It adds support for npm-like config setting set in `.bowerrc`. When set to true, the "save" setting causes the install and uninstall commands to act as if the user had specified `--save`. Likewise, when set to true, the "save-exact" setting causes the install command to act as if the user had specified `--save-exact`. So as not to break the API, when set to false or omitted, these commands behave as before.

One small note: [`lib/commands/install.js`](https://github.com/bower/bower/blob/master/lib/commands/install.js#L12) already checked for a "default-save" setting. I'm not sure if this is documented anywhere, but I left it in place in case any users are depending on this.