### PR TITLE
Rename the es6 module type to es2015

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -190,7 +190,7 @@ function promptUser(logger, json) {
             'name': 'moduleType',
             'message': 'what types of modules does this package expose?',
             'type': 'checkbox',
-            'choices': ['amd', 'es6', 'globals', 'node', 'yui']
+            'choices': ['amd', 'es2015', 'globals', 'node', 'yui']
         },
         {
             'name': 'keywords',


### PR DESCRIPTION
Update the module type `es6` to `es2015` to comply with the ecmascript [standards](http://www.ecma-international.org/ecma-262/6.0/).