### PR TITLE
Replace all occurrences of % character in hook commands.

### DIFF
--- a/lib/core/scripts.js
+++ b/lib/core/scripts.js
@@ -83,7 +83,8 @@ var hook = function (action, ordered, config, logger, packages, installed, json)
     }
 
     var orderedPackages = ordered ? orderByDependencies(packages, installed, json) : mout.object.keys(packages);
-    var cmdString = mout.string.replace(config.scripts[action], '%', orderedPackages.join(' '));
+    var placeholder = new RegExp('%', 'g');
+    var cmdString = mout.string.replace(config.scripts[action], placeholder, orderedPackages.join(' '));
     return run(cmdString, action, logger, config);
 };
 

--- a/test/core/scripts.js
+++ b/test/core/scripts.js
@@ -25,9 +25,9 @@ describe('scripts', function () {
     var config = {
         cwd: tempDir,
         scripts: {
-            preinstall: touch('preinstall_%'),
-            postinstall: touch('postinstall_%'),
-            preuninstall: touch('preuninstall_%')
+            preinstall: touch('preinstall_%_%'),
+            postinstall: touch('postinstall_%_%'),
+            preuninstall: touch('preuninstall_%_%')
         }
     };
 
@@ -45,8 +45,8 @@ describe('scripts', function () {
         .install([packageDir], undefined, config)
         .on('end', function (installed) {
 
-            expect(fs.existsSync(path.join(tempDir, 'preinstall_' + packageName))).to.be(true);
-            expect(fs.existsSync(path.join(tempDir, 'postinstall_' + packageName))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'preinstall_' + packageName + '_' + packageName))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'postinstall_' + packageName + '_' + packageName))).to.be(true);
 
             next();
         });
@@ -59,7 +59,7 @@ describe('scripts', function () {
         .uninstall([packageName], undefined, config)
         .on('end', function (installed) {
 
-            expect(fs.existsSync(path.join(tempDir, 'preuninstall_' + packageName))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'preuninstall_' + packageName + '_' + packageName))).to.be(true);
 
             next();
         });


### PR DESCRIPTION
Fixes #2174 
> % character replaced only on the first occurance in each of .bowerrc scripts