### PR TITLE
[eslint] fix indentation to 4 spaces

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@ rules:
   valid-typeof: 2
   no-fallthrough: 2
   quotes: [2, "single", "avoid-escape"]
-  indent: [2, 2]
+  indent: [2, 4]
   comma-spacing: 2
   semi: 2
   space-infix-ops: 2


### PR DESCRIPTION
Changed the indentation from 2 to 4 spaces in .eslintrc files.
All the code is using this convention and .jscsrc already define 4 as
the right value.