### PR TITLE
Fix hooks to support shell operators

### DIFF
--- a/lib/core/scripts.js
+++ b/lib/core/scripts.js
@@ -1,7 +1,6 @@
 var mout = require('mout');
 var cmd = require('../util/cmd');
 var Q = require('q');
-var shellquote = require('shell-quote');
 
 var orderByDependencies = function (packages, installed, json) {
     var ordered = [];
@@ -54,8 +53,8 @@ var run = function (cmdString, action, logger, config) {
 
     //pass env + BOWER_PID so callees can identify a preinstall+postinstall from the same bower instance
     var env = mout.object.mixIn({ 'BOWER_PID': process.pid }, process.env);
-    var args = shellquote.parse(cmdString, env);
-    var cmdName = args[0];
+    var cmdName = 'sh';
+    var args = ['-c', cmdString];
     mout.array.remove(args, cmdName); //no rest() in mout
 
     var options = {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "rimraf": "^2.2.8",
     "semver": "^2.3.0",
     "semver-utils": "^1.1.1",
-    "shell-quote": "^1.4.2",
     "stringify-object": "^1.0.0",
     "tar-fs": "^1.4.1",
     "tmp": "0.0.28",

--- a/test/core/scripts.js
+++ b/test/core/scripts.js
@@ -135,4 +135,39 @@ describe('scripts', function () {
 
     });
 
+    it('should process preuninstall hooks with shell operators properly.', function (next) {
+
+        config.scripts.preuninstall = touch('preuninstall_test_ping_%') + ' && ' + touch('preuninstall_test_pong');
+
+        bower.commands
+        .uninstall([packageName], undefined, config)
+        .on('end', function (installed) {
+
+            expect(fs.existsSync(path.join(tempDir, 'preuninstall_test_ping_' + packageName))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'preuninstall_test_pong'))).to.be(true);
+
+            next();
+        });
+
+    });
+
+    it('should process preinstall and postinstall hooks with shell operators properly.', function (next) {
+
+        config.scripts.preinstall = touch('preinstall_test_ping_%') + ' && ' + touch('preinstall_test_pong');
+        config.scripts.postinstall = touch('postinstall_test_ping') + ' && ' + touch('postinstall_test_pong_%');
+
+        bower.commands
+        .install([packageDir], undefined, config)
+        .on('end', function (installed) {
+
+            expect(fs.existsSync(path.join(tempDir, 'preinstall_test_ping_' + packageName))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'preinstall_test_pong'))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'postinstall_test_ping'))).to.be(true);
+            expect(fs.existsSync(path.join(tempDir, 'postinstall_test_pong_' + packageName))).to.be(true);
+
+            next();
+        });
+
+    });
+
 });


### PR DESCRIPTION
Hi @sheerun , this PR is for supporting shell operators in preinstall, postinstall and preuninstall hooks, and fixes the issue #1594.

Thanks!