### PR TITLE
2200 Fix invalid version can not found branch

### DIFF
--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -156,6 +156,9 @@ GitResolver.prototype._findResolution = function (target) {
         self.tags(that._source)
     ])
     .spread(function (branches, tags) {
+        // #2200 When version is invalid, replace '^' to v
+        target = target.replace(/^\^/, 'v');
+
         // Use hasOwn because a branch/tag could have a name like "hasOwnProperty"
         if (mout.object.hasOwn(tags, target)) {
             return that._resolution = { type: 'tag', tag: target, commit: tags[target] };


### PR DESCRIPTION
#2200 
When bower.json has version like '^3.6.1+1', it is a invliad version,  repleace '^' to 'v' and find the branch or tags