### PR TITLE
Reuse the files selected in jshint for jscs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,16 +32,7 @@ module.exports = function (grunt) {
                 config: '.jscsrc',
                 fix: true
             },
-            files: [
-                'Gruntfile.js',
-                'bin/*',
-                'lib/**/*.js',
-                'test/**/*.js',
-                '!test/assets/**/*',
-                '!test/reports/**/*',
-                '!test/sample/**/*',
-                '!test/tmp/**/*'
-            ]
+            files: ['<%= jshint.files %>']
         },
         simplemocha: {
             options: {


### PR DESCRIPTION
I think that if we are using the same files we could reuse them as in `watch`.