### PR TITLE
Remove the unregister command

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -76,6 +76,5 @@ module.exports = {
     search: commandFactory('./search'),
     update: commandFactory('./update'),
     uninstall: commandFactory('./uninstall'),
-    unregister: commandFactory('./unregister'),
     version: commandFactory('./version')
 };

--- a/lib/templates/json/help.json
+++ b/lib/templates/json/help.json
@@ -18,7 +18,6 @@
         "search":          "Search for a package by name",
         "update":          "Update a local package",
         "uninstall":       "Remove a local package",
-        "unregister":      "Remove a package from the registry",
         "version":         "Bump a package version"
     },
     "options": [


### PR DESCRIPTION
SInce the `unregister` command is temporarily disabled I think that we should delete it from the help view and` './commands'` export.