### PR TITLE
Download tar archives from https://github when possible

### DIFF
--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -29,9 +29,6 @@ function GitHubResolver(decEndpoint, config, logger) {
         this._source += '.git';
     }
 
-    // Check if it's public
-    this._public = mout.string.startsWith(this._source, 'git://');
-
     // Use https:// rather than git:// if on a proxy
     if (this._config.proxy || this._config.httpsProxy) {
         this._source = this._source.replace('git://', 'https://');
@@ -49,14 +46,10 @@ mout.object.mixIn(GitHubResolver, GitRemoteResolver);
 // -----------------
 
 GitHubResolver.prototype._checkout = function () {
-    // Only fully works with public repositories and tags
-    // Could work with https/ssh protocol but not with 100% certainty
-    if (!this._public || !this._resolution.tag) {
-        return GitRemoteResolver.prototype._checkout.call(this);
-    }
-
     var msg;
-    var tarballUrl = 'https://github.com/' + this._org + '/' + this._repo + '/archive/' + this._resolution.tag + '.tar.gz';
+    var name = this._resolution.tag || this._resolution.branch || this._resolution.commit;
+    var tarballUrl = 'https://github.com/' + this._org + '/' + this._repo + '/archive/' + name + '.tar.gz';
+
     var file = path.join(this._tempDir, 'archive.tar.gz');
     var reqHeaders = {};
     var that = this;
@@ -121,7 +114,6 @@ GitHubResolver.prototype._checkout = function () {
 
         return that._cleanTempDir()
         .then(GitRemoteResolver.prototype._checkout.bind(that));
-
     });
 };
 

--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -26,10 +26,18 @@ function GitResolver(decEndpoint, config, logger) {
     // anyway
     mkdirp.sync(config.storage.empty);
     process.env.GIT_TEMPLATE_DIR = config.storage.empty;
+
     if (!config.strictSsl) {
         process.env.GIT_SSL_NO_VERIFY = 'true';
     }
-    process.env.GIT_TERMINAL_PROMPT = config.interactive ? '1' : '0';
+
+    if (!config.interactive) {
+        process.env.GIT_TERMINAL_PROMPT = '0';
+
+        if (!process.env.SSH_ASKPASS) {
+            process.env.SSH_ASKPASS = 'echo';
+        }
+    }
 
     Resolver.call(this, decEndpoint, config, logger);
 


### PR DESCRIPTION
This fixes #2247 as git checkout often fails on older git versions.

Additionally .tar.gz archives are downloaded for commits and branches.
