### PR TITLE
Check if version is valid

### DIFF
--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -206,7 +206,7 @@ GitResolver.prototype._savePkgMeta = function (meta) {
         version = semver.clean(this._resolution.tag);
 
         // Warn if the package meta version is different than the resolved one
-        if (typeof meta.version === 'string' && semver.neq(meta.version, version)) {
+        if (typeof meta.version === 'string' && semver.valid(meta.version) && semver.neq(meta.version, version)) {
             this._logger.warn('mismatch', 'Version declared in the json (' + meta.version + ') is different than the resolved one (' + version + ')', {
                 resolution: this._resolution,
                 pkgMeta: meta


### PR DESCRIPTION
semver.neq throws error when version is not valid. It should be catched and logged or simply ignored by this check. I've been using npm-check-updates package and it crashes because of this:

```
C:\DEV>ncu -m bower
Unhandled rejection TypeError: Invalid Version: 2.2-jsdw
    at new SemVer (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\semver\semver.js:273:11)
    at compare (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\semver\semver.js:460:10)
    at Object.neq (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\semver\semver.js:504:10)
    at GitHubResolver.GitResolver._savePkgMeta (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\core\resolvers
\GitResolver.js:209:56)
    at GitHubResolver._savePkgMeta (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\core\resolvers\GitHubResol
ver.js:134:53)
    at _fulfilled (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\q\q.js:834:54)
    at self.promiseDispatch.done (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\q\q.js:863:30)
    at Promise.promise.promiseDispatch (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\q\q.js:79
6:13)
    at C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\q\q.js:604:44
    at runSingle (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\q\q.js:137:13)
    at flush (C:\Users\jamat\AppData\Roaming\npm\node_modules\bower\lib\node_modules\q\q.js:125:13)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
