### PR TITLE
Allow `@` to be used as a divider with cli: install and info.

### DIFF
--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -9,6 +9,9 @@ function info(logger, endpoint, property, config) {
         return;
     }
 
+    // handle @ as version divider
+    endpoint = endpoint.replace('@', '#');
+
     var repository;
     var decEndpoint;
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -16,6 +16,8 @@ function install(logger, endpoints, options, config) {
     // Convert endpoints to decomposed endpoints
     endpoints = endpoints || [];
     decEndpoints = endpoints.map(function (endpoint) {
+        // handle @ as version divider
+        endpoint = endpoint.replace('@', '#');
         return endpointParser.decompose(endpoint);
     });
 

--- a/test/commands/info.js
+++ b/test/commands/info.js
@@ -49,4 +49,17 @@ describe('bower info', function () {
             });
         });
     });
+    it('should handle @ as a divider', function () {
+        return helpers.run(info, [mainPackage.path + '@0.1.3']).spread(function (results) {
+            expect(results).to.eql(
+                {
+                    name: 'package',
+                    version: '0.1.3',
+                    homepage: 'http://bower.io',
+                    description: 'Hello world! Hello!'
+                }
+            );
+        });
+
+    });
 });

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -726,21 +726,17 @@ describe('bower install', function () {
             expect(tempDir.read(path.join('bower_components', 'package', 'package.tar'))).to.contain('test');
         });
     });
-    it('should handle @ as a divider', function (done) {
-        // Run `bower install package@1.0.1`
-        var binRunner = helpers.runBin(['install', gitPackage.path + '@' + gitPackage.latestGitTag()]);
+    it('should handle @ as a divider', function () {
+        this.timeout(10000);
 
-        // There should be no error output
-        expect(binRunner.stderr.toString()).to.be('');
-        // A checkout response should be given
-        expect(binRunner.stdout.toString()).to.contain('checkout ' + gitPackage.latestGitTag());
-
-        //clean up temp files
-        return rimraf(path.join(__dirname, '../../bower_components'), function (err) {
-            if (err) {
-                console.warn('failed to delete temporary `bower_components`');
+        return helpers.run(install, [
+            ['empty@1.0.1'], {
+                save: true
             }
-            done();
+        ]).then(function () {
+
+            expect(tempDir.readJson('bower.json').dependencies).to.eql({empty: '1.0.1'});
         });
+
     });
 });

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -726,4 +726,21 @@ describe('bower install', function () {
             expect(tempDir.read(path.join('bower_components', 'package', 'package.tar'))).to.contain('test');
         });
     });
+    it('should handle @ as a divider', function (done) {
+        // Run `bower install package@1.0.1`
+        var binRunner = helpers.runBin(['install', gitPackage.path + '@' + gitPackage.latestGitTag()]);
+
+        // There should be no error output
+        expect(binRunner.stderr.toString()).to.be('');
+        // A checkout response should be given
+        expect(binRunner.stdout.toString()).to.contain('checkout ' + gitPackage.latestGitTag());
+
+        //clean up temp files
+        return rimraf(path.join(__dirname, '../../bower_components'), function (err) {
+            if (err) {
+                console.warn('failed to delete temporary `bower_components`');
+            }
+            done();
+        });
+    });
 });

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -727,7 +727,6 @@ describe('bower install', function () {
         });
     });
     it('should handle @ as a divider', function () {
-        this.timeout(10000);
 
         return helpers.run(install, [
             ['empty@1.0.1'], {

--- a/test/commands/install.js
+++ b/test/commands/install.js
@@ -727,15 +727,12 @@ describe('bower install', function () {
         });
     });
     it('should handle @ as a divider', function () {
-
         return helpers.run(install, [
             ['empty@1.0.1'], {
                 save: true
             }
         ]).then(function () {
-
             expect(tempDir.readJson('bower.json').dependencies).to.eql({empty: '1.0.1'});
         });
-
     });
 });


### PR DESCRIPTION
`@` is replaced with `#` as part of the `info` and `install` commands.