### PR TITLE
Partially address ticket #2336

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "p-throttler": "0.1.1",
     "promptly": "0.2.0",
     "q": "^1.1.2",
-    "request": "2.67.0",
+    "request": "2.74.0",
     "request-progress": "0.3.1",
     "requireg": "^0.1.5",
     "resolve": "^1.1.7",

--- a/packages/bower-registry-client/package.json
+++ b/packages/bower-registry-client/package.json
@@ -13,7 +13,7 @@
     "async": "^0.2.8",
     "graceful-fs": "^4.0.0",
     "lru-cache": "^2.3.0",
-    "request": "^2.51.0",
+    "request": "^2.74.0",
     "request-replay": "^0.2.0",
     "rimraf": "^2.2.0",
     "mkdirp": "^0.3.5"


### PR DESCRIPTION
The commit bump the direct dependency request to version 2.74.0

In order for the fix to be complete the node-request-reply will have to be
updated as well as soon that https://github.com/IndigoUnited/node-request-replay/pull/7
will be merged and a new package will be released.
