### PR TITLE
Do not store resolutions with force-latest when --dont-save-resolutions is used

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -815,7 +815,9 @@ Manager.prototype._electSuitable = function (name, semvers, nonSemvers) {
         });
 
         // Save resolution
-        this._storeResolution(picks[suitable]);
+        if (!this._config.argv.cooked.includes('--dont-save-resolutions')) {
+          this._storeResolution(picks[suitable]);
+        }
 
         return Q.resolve(picks[suitable]);
     }

--- a/lib/templates/json/help-install.json
+++ b/lib/templates/json/help-install.json
@@ -40,6 +40,10 @@
             "shorthand":   "-E",
             "flag":        "--save-exact",
             "description": "Configure installed packages with an exact version rather than semver"
+        },
+        {
+            "flag":        "--dont-save-resolutions",
+            "description": "Causes bower to not automatically save resolutions to bower.json when force-latest is used"
         }
     ]
 }

--- a/lib/templates/json/help-update.json
+++ b/lib/templates/json/help-update.json
@@ -29,6 +29,10 @@
             "shorthand":   "-D",
             "flag":        "--save-dev",
             "description": "Update devDependencies in bower.json"
+        },
+        {
+            "flag":        "--dont-save-resolutions",
+            "description": "Causes bower to not automatically save resolutions to bower.json when force-latest is used"
         }
     ]
 }


### PR DESCRIPTION
Closes #2344

Without this, there's no way to prevent `--force-latest` from modifying bower.json when it resolves a conflict.
This adds a `--dont-save-resolutions` to prevent that.

Not sure this is the best way, but it's the compatible way :).

Also, I have no idea how to get at the parsed options in `Manager`, directly looking at cooked argv (`this._config.argv.cooked`) is probably not the correct way..

Thoughts anyone? :)
