### PR TITLE
Update package repository information

### DIFF
--- a/packages/bower-config/package.json
+++ b/packages/bower-config/package.json
@@ -4,7 +4,7 @@
   "description": "The Bower config reader and writer.",
   "author": "Twitter",
   "license": "MIT",
-  "repository": "bower/config",
+  "repository": "https://github.com/bower/bower/tree/master/packages/bower-config",
   "main": "lib/Config",
   "homepage": "http://bower.io",
   "engines": {

--- a/packages/bower-endpoint-parser/package.json
+++ b/packages/bower-endpoint-parser/package.json
@@ -9,10 +9,7 @@
       "url": "https://github.com/bower/endpoint-parser/blob/master/LICENSE"
     }
   ],
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/bower/endpoint-parser.git"
-  },
+  "repository": "https://github.com/bower/bower/tree/master/packages/bower-endpoint-parser",
   "main": "index.js",
   "engines": {
     "node": ">=0.8.0"

--- a/packages/bower-json/package.json
+++ b/packages/bower-json/package.json
@@ -4,7 +4,7 @@
   "description": "Read bower.json files with semantics, normalisation, defaults and validation",
   "author": "Twitter",
   "license": "MIT",
-  "repository": "bower/json",
+  "repository": "https://github.com/bower/bower/tree/master/packages/bower-json",
   "main": "lib/json",
   "engines": {
     "node": ">=0.10.0"

--- a/packages/bower-logger/package.json
+++ b/packages/bower-logger/package.json
@@ -9,7 +9,7 @@
       "url": "https://github.com/bower/logger/blob/master/LICENSE"
     }
   ],
-  "repository": "bower/logger",
+  "repository": "https://github.com/bower/bower/tree/master/packages/bower-logger",
   "main": "lib/Logger",
   "engines": {
     "node": ">=0.10.0"

--- a/packages/bower-registry-client/package.json
+++ b/packages/bower-registry-client/package.json
@@ -4,7 +4,7 @@
   "description": "Provides easy interaction with the Bower registry",
   "author": "Twitter",
   "license": "MIT",
-  "repository": "bower/registry-client",
+  "repository": "https://github.com/bower/bower/tree/master/packages/bower-registry-client",
   "main": "Client",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Currently the link to the repository on these packages are dead (eg see [bower-json](https://www.npmjs.com/package/bower-json) which links to [bower/json](https://github.com/bower/json).

This commit will fix the links to the code.

I'm not familiar enough with the NPM package structure if this is the best solution or if there are others. Optimally I would like to link directly to the subfolder ./packages/bower-json within bower/bower.

I'm fine if you do not want to merge this PR for whatever reason.

Johannes
