### PR TITLE
add warning message to show which file the warning comes from

### DIFF
--- a/lib/util/readJson.js
+++ b/lib/util/readJson.js
@@ -19,7 +19,9 @@ function readJson(file, options) {
 
         if (options.logger) {
             var issues = bowerJson.getIssues(json);
-
+            if (issues.warnings.length > 0){
+                options.logger.warn('invalid-meta', 'for:' + jsonFile);
+            }
             issues.warnings.forEach(function (warning) {
                 options.logger.warn('invalid-meta', warning);
             });


### PR DESCRIPTION
Enhancement regarding #2355 
Add a warning message and show jsonFile before showing `issues.warnings`

Here is what it looks like after this PR:
![screen shot 2016-09-09 at 9 26 37 am](https://cloud.githubusercontent.com/assets/198821/18370814/61f7532c-7673-11e6-9889-4e6908e2f4ca.png)
