### PR TITLE
Fix #2360 by reverting "set GIT_SSL_NO_VERIFY for opposite value than

### DIFF
--- a/lib/core/resolvers/GitResolver.js
+++ b/lib/core/resolvers/GitResolver.js
@@ -26,7 +26,9 @@ function GitResolver(decEndpoint, config, logger) {
     // anyway
     mkdirp.sync(config.storage.empty);
     process.env.GIT_TEMPLATE_DIR = config.storage.empty;
-    process.env.GIT_SSL_NO_VERIFY = (!config.strictSsl).toString();
+    if (!config.strictSsl) {
+        process.env.GIT_SSL_NO_VERIFY = 'true';
+    }
     process.env.GIT_TERMINAL_PROMPT = config.interactive ? '1' : '0';
 
     Resolver.call(this, decEndpoint, config, logger);

--- a/test/core/resolvers/gitResolver.js
+++ b/test/core/resolvers/gitResolver.js
@@ -50,16 +50,17 @@ describe('GitResolver', function () {
             expect(process.env).to.not.have.property('GIT_SSL_NO_VERIFY');
 
             resolver = new GitResolver(decEndpoint, defaultConfig(), logger);
-            expect(process.env).to.have.property('GIT_SSL_NO_VERIFY', 'false');
-            delete process.env.GIT_SSL_NO_VERIFY;
+            expect(process.env).to.not.have.property('GIT_SSL_NO_VERIFY');
 
             resolver = new GitResolver(decEndpoint, defaultConfig({strictSsl: false}), logger);
             expect(process.env).to.have.property('GIT_SSL_NO_VERIFY', 'true');
             delete process.env.GIT_SSL_NO_VERIFY;
 
+            // git only checks the existence of GIT_SSL_NO_VERIFY.
+            // git does NOT check whether is true of false.
+            // Hence not exporting GIT_SSL_NO_VERIFY is effectively equivalent to 'false'
             resolver = new GitResolver(decEndpoint, defaultConfig({strictSsl: true}), logger);
-            expect(process.env).to.have.property('GIT_SSL_NO_VERIFY', 'false');
-            delete process.env.GIT_SSL_NO_VERIFY;
+            expect(process.env).to.not.have.property('GIT_SSL_NO_VERIFY');
         });
     });
 


### PR DESCRIPTION
Fix #2360 by reverting "set GIT_SSL_NO_VERIFY for opposite value than strictSsl"

This reverts commit f0a54d0018927f8f1cf85cb6c7e12a37cea49333 and adds some comments in the tests
