### PR TITLE
Prefer exact versions when dissecting dependencies

### DIFF
--- a/lib/core/Manager.js
+++ b/lib/core/Manager.js
@@ -587,6 +587,17 @@ Manager.prototype._dissect = function () {
                 }
             }
 
+            // If they are equal and one of them is an exact target,
+            // give higher priority
+            if (!result) {
+                if (first.target === first.pkgMeta.version) {
+                    return -1;
+                }
+                if (second.target === second.pkgMeta.version) {
+                    return 1;
+                }
+            }
+
             return result;
         });
 

--- a/test/core/Manager.js
+++ b/test/core/Manager.js
@@ -34,6 +34,31 @@ describe('Manager', function () {
         next();
     });
 
+    describe('resolve', function () {
+        it('prefers exact versions over ranges', function () {
+            manager._resolved = {
+                ember: [
+                    {
+                        target: '>=1.4',
+                        pkgMeta: { version: '2.7.0' }
+                    },
+                    {
+                        target: '2.7.0',
+                        pkgMeta: { version: '2.7.0' }
+                    }
+                ]
+            };
+
+            return manager.resolve().then(function () {
+                expect(manager._dissected).to.eql({
+                    ember: {
+                        target: '2.7.0',
+                        pkgMeta: { version: '2.7.0' }
+                    }
+                });
+            });
+        });
+    });
 
     describe('_areCompatible', function () {
         describe('resolved is being fetched', function () {


### PR DESCRIPTION
When a project has multiple dependencies on the same package, we try to find one that resolves to a version that also satisfies all of the other constraints. Dependencies are checked in the order that they were resolved, which is dependent on network latency and essentially random. If there are multiple valid resolutions, running `bower install` with the same `bower.json` file won't always produce the same result, which can lead to inconsistent behaviour across environments.

If one of the dependencies specifies an exact version, we should prefer it over others that specify a range of versions. This is consistent with how we already deprioritise wildcard targets - we want to choose the most specific target of the highest version which resolves correctly.
