### PR TITLE
Fix with cache, because must be no case sensitive.

### DIFF
--- a/lib/core/ResolveCache.js
+++ b/lib/core/ResolveCache.js
@@ -11,6 +11,10 @@ var semver = require('../util/semver');
 var readJson = require('../util/readJson');
 var copy = require('../util/copy');
 
+function _md5(source) {
+    return md5(source.toLowerCase());
+}
+
 function ResolveCache(config) {
     // TODO: Make some config entries, such as:
     //       - Max MB
@@ -41,7 +45,7 @@ function ResolveCache(config) {
 // -----------------
 
 ResolveCache.prototype.retrieve = function (source, target) {
-    var sourceId = md5(source);
+    var sourceId = _md5(source);
     var dir = path.join(this._dir, sourceId);
     var that = this;
 
@@ -109,7 +113,7 @@ ResolveCache.prototype.store = function (canonicalDir, pkgMeta) {
 
     return promise
     .then(function (pkgMeta) {
-        sourceId = md5(pkgMeta._source);
+        sourceId = _md5(pkgMeta._source);
         release = that._getPkgRelease(pkgMeta);
         dir = path.join(that._dir, sourceId, release);
         pkgLock = path.join(that._lockDir, sourceId + '-' + release + '.lock');
@@ -165,7 +169,7 @@ ResolveCache.prototype.store = function (canonicalDir, pkgMeta) {
 };
 
 ResolveCache.prototype.eliminate = function (pkgMeta) {
-    var sourceId = md5(pkgMeta._source);
+    var sourceId = _md5(pkgMeta._source);
     var release = this._getPkgRelease(pkgMeta);
     var dir = path.join(this._dir, sourceId, release);
     var that = this;
@@ -212,7 +216,7 @@ ResolveCache.prototype.reset = function () {
 };
 
 ResolveCache.prototype.versions = function (source) {
-    var sourceId = md5(source);
+    var sourceId = _md5(source);
 
     return this._getVersions(sourceId)
     .spread(function (versions) {


### PR DESCRIPTION
For example:

Two dependencies like “https://github.com/PolymerElements/iron-flex-layout.git” must be equal to “https://github.com/polymerelements/iron-flex-layout.git”

But in the cache is treated as differents folders:

~/.cache/bower/packages/444ea84ad1b11545629269bdc8d5330e/
~/.cache/bower/packages/9170ac518f979438268666845fc8f0fb/

$ md5 -s https://github.com/PolymerElements/iron-flex-layout.git
MD5 ("https://github.com/PolymerElements/iron-flex-layout.git") = 444ea84ad1b11545629269bdc8d5330e

$ md5 -s https://github.com/polymerelements/iron-flex-layout.git
MD5 ("https://github.com/polymerelements/iron-flex-layout.git") = 9170ac518f979438268666845fc8f0fb