### PR TITLE
Remove deprecated option in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: node_js
 
 # Use node 8 for build


### PR DESCRIPTION
`sudo: false` tells Travis to run on the container based infrastructure, which is being merged into the normal one.  This means no actual changes will come out of this.  