### PR TITLE
Allow to overide github url using GitHubResolver

### DIFF
--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -38,6 +38,12 @@ function GitHubResolver(decEndpoint, config, logger) {
     this._shallowClone = function() {
         return Q.resolve(true);
     };
+    
+    // Allow to overide github url
+    this._githuburl = "https://github.com";
+    if (this._config.githuburl) {
+       this._githuburl = this._config.githuburl;
+    }
 }
 
 util.inherits(GitHubResolver, GitRemoteResolver);
@@ -52,7 +58,8 @@ GitHubResolver.prototype._checkout = function() {
         this._resolution.branch ||
         this._resolution.commit;
     var tarballUrl =
-        'https://github.com/' +
+        this._githuburl + 
+        '/' +
         this._org +
         '/' +
         this._repo +

--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -38,11 +38,11 @@ function GitHubResolver(decEndpoint, config, logger) {
     this._shallowClone = function() {
         return Q.resolve(true);
     };
-    
+
     // Allow to overide github url
-    this._githuburl = "https://github.com";
+    this._githuburl = 'https://github.com';
     if (this._config.githuburl) {
-       this._githuburl = this._config.githuburl;
+        this._githuburl = this._config.githuburl;
     }
 }
 
@@ -58,7 +58,7 @@ GitHubResolver.prototype._checkout = function() {
         this._resolution.branch ||
         this._resolution.commit;
     var tarballUrl =
-        this._githuburl + 
+        this._githuburl +
         '/' +
         this._org +
         '/' +


### PR DESCRIPTION
Hi,

In order to not use not directly https://github.com but an artifactory that is giving access to https://github.com we like to change the url in the github resolver. 

I made some tries patching the file in a bower install it allow to access to tarball from github though the artifactory generic repository.

So this PR add a new argument in `.bowerrc` to allow to configure that
```
        "githuburl": "https://artifactory/github_remote"
```
Maybe something like `tarball-archive-url` is more clear, let me know ?

Best Regards,

Michel.