### PR TITLE
Fix typos across bower repo

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -20,7 +20,7 @@ function bump(logger, config, versionArg, message) {
     var newVersion;
 
     if (!versionArg) {
-        throw createError('No <version> agrument provided', 'EREADOPTIONS');
+        throw createError('No <version> argument provided', 'EREADOPTIONS');
     }
 
     return driver

--- a/lib/core/resolvers/pluginResolverFactory.js
+++ b/lib/core/resolvers/pluginResolverFactory.js
@@ -166,7 +166,7 @@ function pluginResolverFactory(resolverFactory, bower) {
         })
             .then(function() {
                 // We pass old _resolution (if hasNew has been called before contents).
-                // So resolver can decide wheter use cached version of contents new one.
+                // So resolver can decide whether use cached version of contents new one.
                 if (typeof resolver.fetch !== 'function') {
                     throw createError(
                         'Resolver does not implement the "fetch" method.'


### PR DESCRIPTION
:writing_hand: **Fix typos across bower repo**

**Files that have typos**

```
bower/lib/commands/version.js:23:40: "agrument" is a misspelling of "argument"
bower/lib/core/resolvers/pluginResolverFactory.js:169:42: "wheter" is a misspelling of "whether"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: