### PR TITLE
docs: Fix simple typo, wheter -> whether

### DIFF
--- a/lib/core/resolvers/pluginResolverFactory.js
+++ b/lib/core/resolvers/pluginResolverFactory.js
@@ -166,7 +166,7 @@ function pluginResolverFactory(resolverFactory, bower) {
         })
             .then(function() {
                 // We pass old _resolution (if hasNew has been called before contents).
-                // So resolver can decide wheter use cached version of contents new one.
+                // So resolver can decide whether use cached version of contents new one.
                 if (typeof resolver.fetch !== 'function') {
                     throw createError(
                         'Resolver does not implement the "fetch" method.'


### PR DESCRIPTION
There is a small typo in lib/core/resolvers/pluginResolverFactory.js.

Should read `whether` rather than `wheter`.

