### PR TITLE
Fix typos in changelog

### DIFF
--- a/packages/bower-json/CHANGELOG.md
+++ b/packages/bower-json/CHANGELOG.md
@@ -1,12 +1,12 @@
-# 0.8.2
+# 0.8.4
 
 - Update deep-extend (security fix)
 
-# 0.8.2
+# 0.8.3
 
 - Fix requires
 
-# 0.8.1
+# 0.8.2
 
 - Drop dependency on meow (vendor ext-name)
 


### PR DESCRIPTION
Versions in the changelog for bower-json seem wrong.