### PR TITLE
issue/2610 Force https instead of git protocol for github

### DIFF
--- a/lib/core/resolvers/GitHubResolver.js
+++ b/lib/core/resolvers/GitHubResolver.js
@@ -29,10 +29,8 @@ function GitHubResolver(decEndpoint, config, logger) {
         this._source += '.git';
     }
 
-    // Use https:// rather than git:// if on a proxy
-    if (this._config.proxy || this._config.httpsProxy) {
-        this._source = this._source.replace('git://', 'https://');
-    }
+    // Use https:// rather than git://
+    this._source = this._source.replace('git://', 'https://');
 
     // Enable shallow clones for GitHub repos
     this._shallowClone = function() {


### PR DESCRIPTION
fixes #2610 

### Fixed
* Force https protocol when the git protocol is specific for github.com

