### PR TITLE
Fixes #2616: Update insecure minimist dependency version

### DIFF
--- a/packages/bower-config/package.json
+++ b/packages/bower-config/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "graceful-fs": "^4.1.3",
-    "minimist": "^0.2.1",
+    "minimist": "^1.2.6",
     "mout": "^1.0.0",
     "osenv": "^0.1.3",
     "untildify": "^2.1.0",


### PR DESCRIPTION
Fixes this security advisory: https://github.com/advisories/GHSA-xvch-5gv4-984h

I reviewed the commits between minimist versions and didn't see anything that looked like it would cause compatibility issues with the one place this dependency is used here, but I did not test exhaustively that the upgrade did not break things.