### PR TITLE
deps(bower-config): upgrade minimist to latest patch version 1.2.6

### DIFF
--- a/packages/bower-config/package.json
+++ b/packages/bower-config/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "graceful-fs": "^4.1.3",
-    "minimist": "^0.2.1",
+    "minimist": "^1.2.6",
     "mout": "^1.0.0",
     "osenv": "^0.1.3",
     "untildify": "^2.1.0",


### PR DESCRIPTION
Duplicates the change in https://github.com/bower/bower/pull/2617, but uses [a dedicated feature branch](https://github.com/bower/bower/pull/2617#issuecomment-1091973945).

Fixes this security advisory: https://github.com/advisories/GHSA-xvch-5gv4-984h