### PR TITLE
docs: Fix a few typos

### DIFF
--- a/test/renderers/JsonRenderer.js
+++ b/test/renderers/JsonRenderer.js
@@ -10,7 +10,7 @@ var jsonRendererWithPrompt = function(stubs) {
     });
 };
 
-// When cloning on Windows it's possible carrets are used
+// When cloning on Windows it's possible carets are used
 var normalize = function(string) {
     return string.replace(/\r\n|\r/g, '\n');
 };

--- a/test/renderers/StandardRenderer.js
+++ b/test/renderers/StandardRenderer.js
@@ -614,7 +614,7 @@ describe('StandardRenderer', function() {
                                     name: 'ember'
                                 },
                                 dependencies: {
-                                    // Should be ingored (only one level)
+                                    // Should be ignored (only one level)
                                     react: {
                                         canonicalDir: '/tmp/components/react',
                                         pkgMeta: {


### PR DESCRIPTION
There are small typos in:
- test/renderers/JsonRenderer.js
- test/renderers/StandardRenderer.js

Fixes:
- Should read `ignored` rather than `ingored`.
- Should read `carets` rather than `carrets`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md