### PR TITLE
CI: add Node.js 18, 20 & 22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/actions/setup-node/issues/27
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -65,6 +65,7 @@ jobs:
         run: npm test
         env:
           CI: true
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}  # Allow failure on Windows
       - name: bower-logger tests
         run: (cd packages/bower-logger && npm install && npm test)
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,6 +17,31 @@ jobs:
         # https://github.com/actions/setup-node/issues/27
         node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+        # Pin deprecated Node.js versions on Mac to specific MacOS,
+        # as later OS architecture wont support them anymore.
+        - node-version: 6.x
+          os: macOS-13
+        - node-version: 8.x
+          os: macOS-13
+        - node-version: 10.x
+          os: macOS-13
+        - node-version: 12.x
+          os: macOS-13
+        - node-version: 14.x
+          os: macOS-13
+        exclude:
+        # Exclude older Node.js versions from macOS-latest
+        - node-version: 6.x
+          os: macOS-latest
+        - node-version: 8.x
+          os: macOS-latest
+        - node-version: 10.x
+          os: macOS-latest
+        - node-version: 12.x
+          os: macOS-latest
+        - node-version: 14.x
+          os: macOS-latest
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -52,13 +52,13 @@ jobs:
           git config --global core.symlinks true
         if: runner.os == 'Windows'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install
         run: yarn && (cd packages/bower-json && yarn link) && yarn link bower-json
       - name: lint
         run: npm run lint
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: bower tests


### PR DESCRIPTION
All currently supported Node versions were missing from CI version matrix. Add them.

This lead to realization that GIthub Action runner for MacOS-latest does not support Node.js versions older than 16 any more. To keep the old versions supported, pin them to older version MacOS-13, which is the latest version with correct architecture to run those versions.

All Windows actions seem to fail for unrelated reason. They fail on master of Bower as well, so it is not a question changes in this PR.