### PR TITLE
CI: add Node.js 24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/actions/setup-node/issues/27
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
         # Pin deprecated Node.js versions on Mac to specific MacOS,


### PR DESCRIPTION
Add Node 24 to CI version matrix. It is the next LTS version. Seems to pass without new issues.